### PR TITLE
Add LectureVault website for downloadable lectures

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,24 @@
-# Airnbnb
+# LectureVault
+
+LectureVault is a single-page website designed for selling and delivering downloadable lectures. It
+lets students browse your catalog, purchase with PayPal or Stripe, and access downloads instantly
+through interactive purchase modals.
+
+## Features
+
+- Responsive hero, lecture catalog, pricing, FAQ, and contact sections.
+- Category filters for quickly narrowing down lectures.
+- Purchase modals with PayPal button placeholders and Stripe checkout links.
+- Download buttons that unlock after customers confirm payment.
+- Accessible forms for contact and newsletter capture with inline validation feedback.
+
+## Getting Started
+
+1. Replace the placeholder download files in the `downloads/` folder with your real lecture assets
+   or hosted URLs.
+2. Swap the PayPal `hosted_button_id` values with IDs from your PayPal account.
+3. Update the Stripe links to your Payment Links or Checkout Sessions.
+4. Customize the lecture cards and pricing copy in `index.html` to match your catalog.
+
+You can host the static files on any web server or deploy them to services such as GitHub Pages,
+Netlify, or Vercel.

--- a/downloads/ai-foundations-masterclass.pdf
+++ b/downloads/ai-foundations-masterclass.pdf
@@ -1,0 +1,5 @@
+LectureVault Placeholder File
+=============================
+
+This PDF is a placeholder for the "AI Foundations Masterclass" download. Replace this file with
+your actual lecture materials.

--- a/downloads/startup-finance-essentials.pdf
+++ b/downloads/startup-finance-essentials.pdf
@@ -1,0 +1,5 @@
+LectureVault Placeholder File
+=============================
+
+This PDF is a placeholder for the "Startup Finance Essentials" download. Replace this file with
+your actual lecture materials.

--- a/downloads/storytelling-for-video-creators.pdf
+++ b/downloads/storytelling-for-video-creators.pdf
@@ -1,0 +1,5 @@
+LectureVault Placeholder File
+=============================
+
+This PDF is a placeholder for the "Storytelling for Video Creators" download. Replace this file
+with your actual lecture materials.

--- a/index.html
+++ b/index.html
@@ -1,0 +1,436 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>LectureVault | Premium Lecture Downloads</title>
+  <link rel="preconnect" href="https://fonts.googleapis.com" />
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+  <link href="https://fonts.googleapis.com/css2?family=Inter:wght@300;400;600;700&display=swap" rel="stylesheet" />
+  <link rel="stylesheet" href="styles.css" />
+</head>
+<body>
+  <header class="site-header">
+    <div class="container header-content">
+      <a href="#hero" class="brand">LectureVault</a>
+      <nav class="main-nav" aria-label="Primary">
+        <a href="#lectures">Lectures</a>
+        <a href="#how-it-works">How it Works</a>
+        <a href="#pricing">Pricing</a>
+        <a href="#faq">FAQ</a>
+        <a href="#contact" class="btn btn-small btn-outline">Contact</a>
+      </nav>
+      <button class="nav-toggle" aria-expanded="false" aria-controls="mobile-menu" aria-label="Toggle navigation">
+        <span></span>
+        <span></span>
+        <span></span>
+      </button>
+    </div>
+    <nav id="mobile-menu" class="mobile-nav" hidden aria-label="Mobile navigation">
+      <a href="#lectures">Lectures</a>
+      <a href="#how-it-works">How it Works</a>
+      <a href="#pricing">Pricing</a>
+      <a href="#faq">FAQ</a>
+      <a href="#contact" class="btn btn-small btn-outline">Contact</a>
+    </nav>
+  </header>
+
+  <main>
+    <section id="hero" class="hero">
+      <div class="container hero-content">
+        <div class="hero-text">
+          <span class="badge">Downloadable Lecture Library</span>
+          <h1>Deliver your expertise with instant downloads and secure payments.</h1>
+          <p>
+            LectureVault makes it effortless for your students to find, purchase, and download your
+            lectures. Accept PayPal or Stripe, deliver files immediately, and keep everyone in sync.
+          </p>
+          <div class="cta-group">
+            <a class="btn" href="#lectures">Browse Lectures</a>
+            <a class="btn btn-outline" href="#how-it-works">See How It Works</a>
+          </div>
+          <dl class="hero-stats">
+            <div>
+              <dt>1200+</dt>
+              <dd>Happy Learners</dd>
+            </div>
+            <div>
+              <dt>85</dt>
+              <dd>On-Demand Lectures</dd>
+            </div>
+            <div>
+              <dt>24/7</dt>
+              <dd>Instant Access</dd>
+            </div>
+          </dl>
+        </div>
+        <div class="hero-card" role="presentation">
+          <div class="hero-card__header">
+            <h2>Featured Lecture</h2>
+            <p>AI Foundations Masterclass</p>
+          </div>
+          <ul class="hero-card__features">
+            <li>6.5 hours of HD content</li>
+            <li>Downloadable transcripts &amp; slides</li>
+            <li>Includes project workbook</li>
+          </ul>
+          <div class="hero-card__footer">
+            <span class="price">$49</span>
+            <a class="btn btn-small" href="#lectures">Get Access</a>
+          </div>
+        </div>
+      </div>
+      <div class="hero-wave" aria-hidden="true"></div>
+    </section>
+
+    <section class="container section" id="lectures">
+      <header class="section-header">
+        <h2>Curated lectures, ready to download</h2>
+        <p>Each download includes video, audio, transcript, and bonus materials.</p>
+      </header>
+      <div class="filters" role="group" aria-label="Lecture filters">
+        <button class="filter-btn active" data-filter="all">All</button>
+        <button class="filter-btn" data-filter="technology">Technology</button>
+        <button class="filter-btn" data-filter="business">Business</button>
+        <button class="filter-btn" data-filter="creative">Creative</button>
+      </div>
+      <div class="lecture-grid" role="list">
+        <article class="lecture-card" role="listitem" data-category="technology">
+          <div class="lecture-card__body">
+            <span class="tag">Technology</span>
+            <h3>AI Foundations Masterclass</h3>
+            <p>Understand core machine learning concepts, model evaluation, and ethical AI practices.</p>
+            <ul>
+              <li>6.5 hours video • 220 page transcript</li>
+              <li>Includes interactive workbook</li>
+            </ul>
+          </div>
+          <footer class="lecture-card__footer">
+            <span class="price">$49</span>
+            <div class="actions">
+              <button class="btn btn-small" data-modal-target="modal-ai">Purchase</button>
+              <a class="link" href="downloads/ai-foundations-masterclass.pdf" download>Preview</a>
+            </div>
+          </footer>
+        </article>
+
+        <article class="lecture-card" role="listitem" data-category="business">
+          <div class="lecture-card__body">
+            <span class="tag">Business</span>
+            <h3>Startup Finance Essentials</h3>
+            <p>Learn how to budget, forecast, and pitch your startup with confidence.</p>
+            <ul>
+              <li>4.25 hours video • 150 page workbook</li>
+              <li>Includes editable financial models</li>
+            </ul>
+          </div>
+          <footer class="lecture-card__footer">
+            <span class="price">$39</span>
+            <div class="actions">
+              <button class="btn btn-small" data-modal-target="modal-finance">Purchase</button>
+              <a class="link" href="downloads/startup-finance-essentials.pdf" download>Preview</a>
+            </div>
+          </footer>
+        </article>
+
+        <article class="lecture-card" role="listitem" data-category="creative">
+          <div class="lecture-card__body">
+            <span class="tag">Creative</span>
+            <h3>Storytelling for Video Creators</h3>
+            <p>Craft compelling narratives and shot lists for YouTube and streaming platforms.</p>
+            <ul>
+              <li>3 hours video • 95 page creative guide</li>
+              <li>Includes editable storyboarding templates</li>
+            </ul>
+          </div>
+          <footer class="lecture-card__footer">
+            <span class="price">$32</span>
+            <div class="actions">
+              <button class="btn btn-small" data-modal-target="modal-story">Purchase</button>
+              <a class="link" href="downloads/storytelling-for-video-creators.pdf" download>Preview</a>
+            </div>
+          </footer>
+        </article>
+      </div>
+    </section>
+
+    <section class="section section-alt" id="how-it-works">
+      <div class="container split">
+        <div>
+          <header class="section-header">
+            <h2>Simple checkout, immediate delivery</h2>
+            <p>Students choose a lecture, pay securely, and receive instant download access.</p>
+          </header>
+          <ol class="steps">
+            <li>
+              <h3>Choose a lecture</h3>
+              <p>Select from your catalog and open the purchase window to see the details.</p>
+            </li>
+            <li>
+              <h3>Secure payment</h3>
+              <p>Students pay with PayPal or Stripe. Replace the payment links with your own checkout URLs.</p>
+            </li>
+            <li>
+              <h3>Instant download</h3>
+              <p>After payment, the download button unlocks automatically for immediate access.</p>
+            </li>
+          </ol>
+        </div>
+        <div class="feature-card">
+          <h3>Included in every download</h3>
+          <ul>
+            <li>High-resolution MP4 video</li>
+            <li>MP3 audio-only version</li>
+            <li>Annotated PDF transcript</li>
+            <li>Bonus worksheets &amp; resources</li>
+            <li>Lifetime access to updates</li>
+          </ul>
+        </div>
+      </div>
+    </section>
+
+    <section class="section" id="pricing">
+      <div class="container">
+        <header class="section-header">
+          <h2>Bundles that grow with your audience</h2>
+          <p>Offer curated packages or sell lectures individually.</p>
+        </header>
+        <div class="pricing-grid">
+          <article class="pricing-card">
+            <h3>Single Lecture</h3>
+            <p class="price">$29 - $59</p>
+            <ul>
+              <li>Any individual lecture</li>
+              <li>Immediate download access</li>
+              <li>Payment by PayPal or Stripe</li>
+            </ul>
+            <a class="btn btn-small" href="#lectures">Choose a lecture</a>
+          </article>
+          <article class="pricing-card pricing-card--featured">
+            <div class="badge">Popular</div>
+            <h3>Complete Library</h3>
+            <p class="price">$249</p>
+            <ul>
+              <li>Includes every lecture &amp; update</li>
+              <li>One-click Stripe Checkout link</li>
+              <li>Priority support</li>
+            </ul>
+            <a class="btn btn-small" href="#contact">Request bundle link</a>
+          </article>
+          <article class="pricing-card">
+            <h3>Team Access</h3>
+            <p class="price">$499</p>
+            <ul>
+              <li>Up to 10 team members</li>
+              <li>Centralized billing</li>
+              <li>Automated lecture updates</li>
+            </ul>
+            <a class="btn btn-small btn-outline" href="#contact">Talk to sales</a>
+          </article>
+        </div>
+      </div>
+    </section>
+
+    <section class="section section-alt" id="faq">
+      <div class="container">
+        <header class="section-header">
+          <h2>Frequently Asked Questions</h2>
+        </header>
+        <div class="faq">
+          <details>
+            <summary>How do I connect my PayPal and Stripe accounts?</summary>
+            <p>
+              Replace the placeholder PayPal form URL and Stripe checkout links in the purchase modal with your
+              own links. Both providers let you create payment buttons or hosted checkout links without code.
+            </p>
+          </details>
+          <details>
+            <summary>When are downloads released to students?</summary>
+            <p>
+              After payment confirmation, the download button within the modal becomes active. Students can access
+              their files immediately and will receive a confirmation email with the download link if you integrate
+              email automation.
+            </p>
+          </details>
+          <details>
+            <summary>Can I host the lecture files elsewhere?</summary>
+            <p>
+              Absolutely. Replace the download URLs with links to your storage provider such as Dropbox, Google
+              Drive, or a private CDN. This demo uses local files for illustration.
+            </p>
+          </details>
+          <details>
+            <summary>Is there analytics for downloads?</summary>
+            <p>
+              You can connect Google Analytics or your preferred tracking tool to monitor page views and checkout
+              conversions. Stripe and PayPal each provide detailed payment reports.
+            </p>
+          </details>
+        </div>
+      </div>
+    </section>
+
+    <section class="section" id="contact">
+      <div class="container contact">
+        <div>
+          <header class="section-header">
+            <h2>Need a custom lecture bundle?</h2>
+            <p>Fill in the form or email <a href="mailto:hello@lecturevault.com">hello@lecturevault.com</a> for a tailored offer.</p>
+          </header>
+          <ul class="contact-benefits">
+            <li>48-hour response time</li>
+            <li>Bulk licensing discounts</li>
+            <li>White-label options</li>
+          </ul>
+        </div>
+        <form class="contact-form" novalidate>
+          <div class="form-row">
+            <label for="name">Name</label>
+            <input id="name" name="name" type="text" placeholder="Your name" required />
+          </div>
+          <div class="form-row">
+            <label for="email">Email</label>
+            <input id="email" name="email" type="email" placeholder="you@example.com" required />
+          </div>
+          <div class="form-row">
+            <label for="message">Message</label>
+            <textarea id="message" name="message" rows="4" placeholder="Tell us what you need"></textarea>
+          </div>
+          <button type="submit" class="btn btn-small">Send message</button>
+          <p class="form-feedback" role="status" aria-live="polite"></p>
+        </form>
+      </div>
+    </section>
+  </main>
+
+  <footer class="site-footer">
+    <div class="container footer-grid">
+      <div>
+        <a href="#hero" class="brand">LectureVault</a>
+        <p class="footer-text">Delivering high-quality lectures with secure, instant downloads.</p>
+      </div>
+      <div>
+        <h3>Quick Links</h3>
+        <ul>
+          <li><a href="#lectures">Lectures</a></li>
+          <li><a href="#pricing">Pricing</a></li>
+          <li><a href="#faq">FAQ</a></li>
+          <li><a href="#contact">Contact</a></li>
+        </ul>
+      </div>
+      <div>
+        <h3>Stay Updated</h3>
+        <form class="newsletter" novalidate>
+          <label class="sr-only" for="newsletter-email">Email</label>
+          <input id="newsletter-email" type="email" name="email" placeholder="Email address" required />
+          <button type="submit" class="btn btn-small">Join</button>
+          <p class="form-feedback" role="status" aria-live="polite"></p>
+        </form>
+      </div>
+    </div>
+    <p class="legal">© <span id="year"></span> LectureVault. All rights reserved.</p>
+  </footer>
+
+  <div class="modal" id="modal-ai" role="dialog" aria-modal="true" aria-labelledby="modal-ai-title" hidden>
+    <div class="modal__backdrop" data-close></div>
+    <div class="modal__dialog">
+      <button class="modal__close" data-close aria-label="Close">
+        <span>&times;</span>
+      </button>
+      <div class="modal__header">
+        <h2 id="modal-ai-title">AI Foundations Masterclass</h2>
+        <p>Secure your copy with PayPal or Stripe.</p>
+      </div>
+      <div class="modal__content">
+        <ul class="modal__details">
+          <li>6.5 hours on-demand video</li>
+          <li>Transcripts, slides, and workbook</li>
+          <li>Instant download unlock after payment</li>
+        </ul>
+        <div class="modal__checkout">
+          <form class="paypal-form" action="https://www.paypal.com/cgi-bin/webscr" method="post" target="_blank">
+            <input type="hidden" name="cmd" value="_s-xclick" />
+            <input type="hidden" name="hosted_button_id" value="REPLACE_WITH_YOUR_BUTTON_ID" />
+            <button type="submit" class="btn btn-paypal">Pay with PayPal</button>
+          </form>
+          <a class="btn btn-stripe" href="https://buy.stripe.com/test_000000000000" target="_blank" rel="noopener">Pay with Stripe</a>
+        </div>
+        <button class="btn btn-small btn-success" data-unlock="ai">I have completed payment</button>
+        <a class="btn btn-small btn-outline" data-download="ai" href="downloads/ai-foundations-masterclass.pdf" download hidden>
+          Download lecture
+        </a>
+      </div>
+    </div>
+  </div>
+
+  <div class="modal" id="modal-finance" role="dialog" aria-modal="true" aria-labelledby="modal-finance-title" hidden>
+    <div class="modal__backdrop" data-close></div>
+    <div class="modal__dialog">
+      <button class="modal__close" data-close aria-label="Close">
+        <span>&times;</span>
+      </button>
+      <div class="modal__header">
+        <h2 id="modal-finance-title">Startup Finance Essentials</h2>
+        <p>Purchase securely and download immediately.</p>
+      </div>
+      <div class="modal__content">
+        <ul class="modal__details">
+          <li>Budgeting, forecasting, and investor pitch prep</li>
+          <li>Editable financial templates</li>
+          <li>Full transcript and slides</li>
+        </ul>
+        <div class="modal__checkout">
+          <form class="paypal-form" action="https://www.paypal.com/cgi-bin/webscr" method="post" target="_blank">
+            <input type="hidden" name="cmd" value="_s-xclick" />
+            <input type="hidden" name="hosted_button_id" value="REPLACE_WITH_YOUR_BUTTON_ID" />
+            <button type="submit" class="btn btn-paypal">Pay with PayPal</button>
+          </form>
+          <a class="btn btn-stripe" href="https://buy.stripe.com/test_111111111111" target="_blank" rel="noopener">Pay with Stripe</a>
+        </div>
+        <button class="btn btn-small btn-success" data-unlock="finance">I have completed payment</button>
+        <a class="btn btn-small btn-outline" data-download="finance" href="downloads/startup-finance-essentials.pdf" download hidden>
+          Download lecture
+        </a>
+      </div>
+    </div>
+  </div>
+
+  <div class="modal" id="modal-story" role="dialog" aria-modal="true" aria-labelledby="modal-story-title" hidden>
+    <div class="modal__backdrop" data-close></div>
+    <div class="modal__dialog">
+      <button class="modal__close" data-close aria-label="Close">
+        <span>&times;</span>
+      </button>
+      <div class="modal__header">
+        <h2 id="modal-story-title">Storytelling for Video Creators</h2>
+        <p>Secure checkout with PayPal or Stripe.</p>
+      </div>
+      <div class="modal__content">
+        <ul class="modal__details">
+          <li>Story structure frameworks</li>
+          <li>Editable script templates</li>
+          <li>Access to bonus resources</li>
+        </ul>
+        <div class="modal__checkout">
+          <form class="paypal-form" action="https://www.paypal.com/cgi-bin/webscr" method="post" target="_blank">
+            <input type="hidden" name="cmd" value="_s-xclick" />
+            <input type="hidden" name="hosted_button_id" value="REPLACE_WITH_YOUR_BUTTON_ID" />
+            <button type="submit" class="btn btn-paypal">Pay with PayPal</button>
+          </form>
+          <a class="btn btn-stripe" href="https://buy.stripe.com/test_222222222222" target="_blank" rel="noopener">Pay with Stripe</a>
+        </div>
+        <button class="btn btn-small btn-success" data-unlock="story">I have completed payment</button>
+        <a class="btn btn-small btn-outline" data-download="story" href="downloads/storytelling-for-video-creators.pdf" download hidden>
+          Download lecture
+        </a>
+      </div>
+    </div>
+  </div>
+
+  <template id="toast-template">
+    <div class="toast" role="status" aria-live="assertive"></div>
+  </template>
+
+  <script src="scripts.js" defer></script>
+</body>
+</html>

--- a/scripts.js
+++ b/scripts.js
@@ -1,0 +1,123 @@
+(function () {
+  const navToggle = document.querySelector('.nav-toggle');
+  const mobileMenu = document.getElementById('mobile-menu');
+  const filterButtons = document.querySelectorAll('.filter-btn');
+  const lectureCards = document.querySelectorAll('.lecture-card');
+  const modals = document.querySelectorAll('.modal');
+  const toastTemplate = document.getElementById('toast-template');
+  const yearEl = document.getElementById('year');
+  const contactForm = document.querySelector('.contact-form');
+  const newsletterForm = document.querySelector('.newsletter');
+
+  yearEl.textContent = new Date().getFullYear();
+
+  const toggleMobileMenu = () => {
+    const expanded = navToggle.getAttribute('aria-expanded') === 'true';
+    navToggle.setAttribute('aria-expanded', String(!expanded));
+    mobileMenu.toggleAttribute('hidden');
+  };
+
+  navToggle.addEventListener('click', toggleMobileMenu);
+
+  mobileMenu.querySelectorAll('a').forEach((link) => {
+    link.addEventListener('click', () => {
+      if (window.innerWidth <= 860) {
+        toggleMobileMenu();
+      }
+    });
+  });
+
+  const filterLectures = (category) => {
+    lectureCards.forEach((card) => {
+      const matches = category === 'all' || card.dataset.category === category;
+      card.hidden = !matches;
+    });
+  };
+
+  filterButtons.forEach((btn) => {
+    btn.addEventListener('click', () => {
+      filterButtons.forEach((item) => item.classList.remove('active'));
+      btn.classList.add('active');
+      filterLectures(btn.dataset.filter);
+    });
+  });
+
+  const openModal = (id) => {
+    const modal = document.getElementById(id);
+    if (!modal) return;
+    modal.hidden = false;
+    document.body.style.overflow = 'hidden';
+  };
+
+  const closeModal = (modal) => {
+    modal.hidden = true;
+    document.body.style.overflow = '';
+  };
+
+  document.addEventListener('click', (event) => {
+    const trigger = event.target.closest('[data-modal-target]');
+    if (trigger) {
+      openModal(trigger.dataset.modalTarget);
+    }
+
+    if (event.target.matches('[data-close]')) {
+      const modal = event.target.closest('.modal');
+      if (modal) closeModal(modal);
+    }
+  });
+
+  window.addEventListener('keydown', (event) => {
+    if (event.key === 'Escape') {
+      modals.forEach((modal) => {
+        if (!modal.hidden) closeModal(modal);
+      });
+    }
+  });
+
+  const showToast = (message) => {
+    const toast = toastTemplate.content.firstElementChild.cloneNode(true);
+    toast.textContent = message;
+    document.body.appendChild(toast);
+    setTimeout(() => {
+      toast.style.opacity = '0';
+      toast.style.transform = 'translateY(10px)';
+      toast.addEventListener('transitionend', () => toast.remove(), { once: true });
+    }, 2600);
+  };
+
+  document.querySelectorAll('[data-unlock]').forEach((button) => {
+    button.addEventListener('click', () => {
+      const key = button.dataset.unlock;
+      const downloadLink = document.querySelector(`[data-download="${key}"]`);
+      if (!downloadLink) return;
+      downloadLink.hidden = false;
+      showToast('Download unlocked! Enjoy your lecture.');
+    });
+  });
+
+  const setupForm = (form) => {
+    if (!form) return;
+    const feedback = form.querySelector('.form-feedback');
+
+    form.addEventListener('submit', (event) => {
+      event.preventDefault();
+      const formData = new FormData(form);
+      const hasEmptyRequired = Array.from(form.querySelectorAll('[required]')).some((field) => {
+        return !String(formData.get(field.name)).trim();
+      });
+
+      if (hasEmptyRequired) {
+        feedback.textContent = 'Please fill in all required fields.';
+        feedback.style.color = '#ef4444';
+        return;
+      }
+
+      feedback.textContent = 'Thanks! We will get back to you soon.';
+      feedback.style.color = 'var(--color-primary)';
+      form.reset();
+    });
+  };
+
+  setupForm(contactForm);
+  setupForm(newsletterForm);
+})();

--- a/styles.css
+++ b/styles.css
@@ -1,0 +1,679 @@
+:root {
+  --color-bg: #f6f7fb;
+  --color-surface: #ffffff;
+  --color-primary: #3b82f6;
+  --color-primary-dark: #1d4ed8;
+  --color-secondary: #6366f1;
+  --color-accent: #22c55e;
+  --color-text: #1f2937;
+  --color-muted: #6b7280;
+  --shadow-sm: 0 5px 20px rgba(15, 23, 42, 0.08);
+  --shadow-md: 0 12px 30px rgba(15, 23, 42, 0.15);
+  font-family: "Inter", system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+  scroll-behavior: smooth;
+}
+
+* {
+  box-sizing: border-box;
+}
+
+body {
+  margin: 0;
+  color: var(--color-text);
+  background: var(--color-bg);
+  font-size: 16px;
+  line-height: 1.6;
+}
+
+img {
+  max-width: 100%;
+  display: block;
+}
+
+a {
+  color: inherit;
+  text-decoration: none;
+}
+
+a:hover,
+a:focus {
+  color: var(--color-primary);
+}
+
+.container {
+  width: min(1100px, 92vw);
+  margin: 0 auto;
+}
+
+.btn {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: 0.5rem;
+  padding: 0.85rem 1.4rem;
+  border-radius: 999px;
+  font-weight: 600;
+  border: none;
+  cursor: pointer;
+  background: linear-gradient(135deg, var(--color-primary), var(--color-secondary));
+  color: #fff;
+  transition: transform 0.2s ease, box-shadow 0.2s ease;
+  box-shadow: var(--shadow-sm);
+}
+
+.btn:hover,
+.btn:focus {
+  transform: translateY(-2px);
+  box-shadow: var(--shadow-md);
+}
+
+.btn-small {
+  padding: 0.65rem 1.1rem;
+  font-size: 0.95rem;
+}
+
+.btn-outline {
+  background: transparent;
+  color: var(--color-primary);
+  border: 1px solid rgba(59, 130, 246, 0.5);
+  box-shadow: none;
+}
+
+.btn-outline:hover,
+.btn-outline:focus {
+  background: rgba(59, 130, 246, 0.08);
+}
+
+.btn-paypal {
+  background: linear-gradient(135deg, #ffc439, #ff9f0c);
+  color: #1f2937;
+}
+
+.btn-stripe {
+  background: linear-gradient(135deg, #6772e5, #4338ca);
+}
+
+.btn-success {
+  background: linear-gradient(135deg, var(--color-accent), #16a34a);
+}
+
+.site-header {
+  background: var(--color-surface);
+  position: sticky;
+  top: 0;
+  z-index: 10;
+  box-shadow: 0 1px 0 rgba(15, 23, 42, 0.05);
+}
+
+.header-content {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 1rem 0;
+}
+
+.brand {
+  font-weight: 700;
+  font-size: 1.2rem;
+  letter-spacing: -0.02em;
+}
+
+.main-nav {
+  display: flex;
+  align-items: center;
+  gap: 1.5rem;
+  font-weight: 500;
+}
+
+.main-nav a {
+  position: relative;
+}
+
+.main-nav a::after {
+  content: "";
+  position: absolute;
+  left: 0;
+  bottom: -0.35rem;
+  width: 100%;
+  height: 2px;
+  background: var(--color-primary);
+  transform: scaleX(0);
+  transform-origin: right;
+  transition: transform 0.25s ease;
+}
+
+.main-nav a:hover::after,
+.main-nav a:focus::after {
+  transform: scaleX(1);
+  transform-origin: left;
+}
+
+.nav-toggle {
+  display: none;
+  flex-direction: column;
+  gap: 0.35rem;
+  border: none;
+  background: transparent;
+  cursor: pointer;
+}
+
+.nav-toggle span {
+  display: block;
+  width: 1.5rem;
+  height: 2px;
+  background: var(--color-text);
+  transition: transform 0.2s ease, opacity 0.2s ease;
+}
+
+.mobile-nav {
+  display: none;
+  flex-direction: column;
+  padding: 0 1.5rem 1.5rem;
+  gap: 0.85rem;
+  background: var(--color-surface);
+  box-shadow: 0 15px 25px rgba(15, 23, 42, 0.08);
+}
+
+.hero {
+  padding: 6rem 0 4rem;
+  position: relative;
+  overflow: hidden;
+}
+
+.hero-wave {
+  position: absolute;
+  inset: auto 0 0;
+  height: 200px;
+  background: linear-gradient(180deg, rgba(59, 130, 246, 0.08), rgba(59, 130, 246, 0));
+  pointer-events: none;
+}
+
+.hero-content {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
+  gap: 3rem;
+  align-items: center;
+}
+
+.hero-text h1 {
+  font-size: clamp(2.2rem, 4vw + 1rem, 3.5rem);
+  line-height: 1.15;
+  margin-bottom: 1rem;
+}
+
+.hero-text p {
+  font-size: 1.05rem;
+  color: var(--color-muted);
+  max-width: 34rem;
+}
+
+.badge {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.35rem;
+  padding: 0.35rem 0.75rem;
+  background: rgba(59, 130, 246, 0.12);
+  color: var(--color-primary);
+  border-radius: 999px;
+  font-weight: 600;
+  margin-bottom: 1rem;
+}
+
+.hero-stats {
+  display: flex;
+  gap: 2rem;
+  margin-top: 2.5rem;
+}
+
+.hero-stats dt {
+  font-size: 1.8rem;
+  font-weight: 700;
+}
+
+.hero-stats dd {
+  margin: 0;
+  color: var(--color-muted);
+}
+
+.hero-card {
+  background: var(--color-surface);
+  border-radius: 1.5rem;
+  padding: 2rem;
+  box-shadow: var(--shadow-md);
+}
+
+.hero-card__header h2 {
+  margin: 0;
+  font-size: 1.35rem;
+}
+
+.hero-card__header p {
+  margin-top: 0.25rem;
+  color: var(--color-muted);
+}
+
+.hero-card__features {
+  list-style: none;
+  padding: 0;
+  margin: 1.5rem 0;
+  display: grid;
+  gap: 0.75rem;
+}
+
+.hero-card__footer {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+}
+
+.price {
+  font-weight: 700;
+  font-size: 1.25rem;
+}
+
+.section {
+  padding: 5rem 0;
+}
+
+.section-alt {
+  background: var(--color-surface);
+}
+
+.section-header {
+  text-align: center;
+  margin-bottom: 3rem;
+}
+
+.section-header h2 {
+  margin: 0;
+  font-size: clamp(2rem, 3vw + 1rem, 2.8rem);
+}
+
+.section-header p {
+  color: var(--color-muted);
+  max-width: 34rem;
+  margin: 0.75rem auto 0;
+}
+
+.filters {
+  display: flex;
+  justify-content: center;
+  gap: 0.75rem;
+  flex-wrap: wrap;
+  margin-bottom: 2.5rem;
+}
+
+.filter-btn {
+  border: 1px solid rgba(59, 130, 246, 0.3);
+  background: transparent;
+  color: var(--color-muted);
+  padding: 0.5rem 1.2rem;
+  border-radius: 999px;
+  font-weight: 600;
+  cursor: pointer;
+  transition: background 0.2s ease, color 0.2s ease, border 0.2s ease;
+}
+
+.filter-btn.active,
+.filter-btn:hover,
+.filter-btn:focus {
+  background: rgba(59, 130, 246, 0.12);
+  color: var(--color-primary);
+  border-color: var(--color-primary);
+}
+
+.lecture-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(270px, 1fr));
+  gap: 1.8rem;
+}
+
+.lecture-card {
+  background: var(--color-surface);
+  border-radius: 1.25rem;
+  padding: 1.8rem;
+  box-shadow: var(--shadow-sm);
+  display: flex;
+  flex-direction: column;
+  justify-content: space-between;
+  gap: 1.5rem;
+}
+
+.lecture-card__body h3 {
+  margin: 0 0 0.75rem;
+}
+
+.lecture-card__body p {
+  color: var(--color-muted);
+  margin: 0 0 1rem;
+}
+
+.lecture-card__body ul {
+  margin: 0;
+  padding-left: 1.2rem;
+  color: var(--color-muted);
+}
+
+.lecture-card__footer {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+}
+
+.tag {
+  display: inline-flex;
+  align-items: center;
+  padding: 0.3rem 0.75rem;
+  border-radius: 999px;
+  background: rgba(59, 130, 246, 0.08);
+  color: var(--color-primary);
+  font-weight: 600;
+  margin-bottom: 0.75rem;
+}
+
+.link {
+  font-weight: 600;
+  color: var(--color-primary);
+}
+
+.split {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
+  gap: 3rem;
+  align-items: center;
+}
+
+.steps {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: grid;
+  gap: 1.8rem;
+}
+
+.steps h3 {
+  margin-bottom: 0.35rem;
+}
+
+.feature-card {
+  background: linear-gradient(160deg, rgba(59, 130, 246, 0.12), rgba(34, 197, 94, 0.12));
+  border-radius: 1.5rem;
+  padding: 2rem;
+  box-shadow: var(--shadow-sm);
+}
+
+.feature-card ul {
+  margin: 0;
+  padding-left: 1.1rem;
+  color: var(--color-muted);
+}
+
+.pricing-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(250px, 1fr));
+  gap: 2rem;
+}
+
+.pricing-card {
+  background: var(--color-surface);
+  padding: 2rem;
+  border-radius: 1.5rem;
+  box-shadow: var(--shadow-sm);
+  text-align: center;
+  position: relative;
+}
+
+.pricing-card ul {
+  list-style: none;
+  padding: 0;
+  margin: 1.5rem 0;
+  color: var(--color-muted);
+  display: grid;
+  gap: 0.65rem;
+}
+
+.pricing-card--featured {
+  background: linear-gradient(160deg, rgba(59, 130, 246, 0.12), rgba(99, 102, 241, 0.12));
+  border: 1px solid rgba(59, 130, 246, 0.2);
+}
+
+.pricing-card .badge {
+  position: absolute;
+  top: 1.5rem;
+  right: 1.5rem;
+}
+
+.faq {
+  display: grid;
+  gap: 1rem;
+}
+
+.faq details {
+  background: var(--color-surface);
+  border-radius: 1.1rem;
+  padding: 1.5rem;
+  box-shadow: var(--shadow-sm);
+}
+
+.faq summary {
+  font-weight: 600;
+  cursor: pointer;
+}
+
+.contact {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
+  gap: 3rem;
+  align-items: start;
+}
+
+.contact-benefits {
+  margin: 2rem 0 0;
+  padding-left: 1.2rem;
+  color: var(--color-muted);
+}
+
+.contact-form,
+.newsletter {
+  background: var(--color-surface);
+  border-radius: 1.25rem;
+  padding: 2rem;
+  box-shadow: var(--shadow-sm);
+  display: grid;
+  gap: 1.2rem;
+}
+
+.form-row {
+  display: grid;
+  gap: 0.35rem;
+}
+
+label {
+  font-weight: 600;
+  font-size: 0.95rem;
+}
+
+input,
+textarea {
+  width: 100%;
+  border-radius: 0.8rem;
+  border: 1px solid rgba(148, 163, 184, 0.6);
+  padding: 0.85rem 1rem;
+  font: inherit;
+  transition: border 0.2s ease, box-shadow 0.2s ease;
+}
+
+input:focus,
+textarea:focus {
+  outline: none;
+  border-color: var(--color-primary);
+  box-shadow: 0 0 0 3px rgba(59, 130, 246, 0.2);
+}
+
+textarea {
+  resize: vertical;
+}
+
+.form-feedback {
+  margin: 0;
+  min-height: 1.2rem;
+  font-size: 0.9rem;
+  color: var(--color-muted);
+}
+
+.site-footer {
+  background: #0f172a;
+  color: rgba(255, 255, 255, 0.85);
+  padding: 4rem 0 2rem;
+}
+
+.footer-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+  gap: 2.5rem;
+}
+
+.footer-text {
+  max-width: 18rem;
+  color: rgba(255, 255, 255, 0.7);
+}
+
+.site-footer a {
+  color: rgba(255, 255, 255, 0.75);
+}
+
+.site-footer a:hover,
+.site-footer a:focus {
+  color: #fff;
+}
+
+.legal {
+  text-align: center;
+  margin-top: 3rem;
+  color: rgba(255, 255, 255, 0.6);
+}
+
+.sr-only {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  margin: -1px;
+  overflow: hidden;
+  clip: rect(0, 0, 0, 0);
+  white-space: nowrap;
+  border: 0;
+}
+
+.modal {
+  position: fixed;
+  inset: 0;
+  display: grid;
+  place-items: center;
+  padding: 1.5rem;
+}
+
+.modal[hidden] {
+  display: none;
+}
+
+.modal__backdrop {
+  position: absolute;
+  inset: 0;
+  background: rgba(15, 23, 42, 0.55);
+}
+
+.modal__dialog {
+  position: relative;
+  background: var(--color-surface);
+  border-radius: 1.5rem;
+  padding: 2.2rem;
+  box-shadow: var(--shadow-md);
+  width: min(480px, 92vw);
+  max-height: calc(100vh - 3rem);
+  overflow-y: auto;
+}
+
+.modal__close {
+  position: absolute;
+  top: 1rem;
+  right: 1rem;
+  border: none;
+  background: rgba(148, 163, 184, 0.2);
+  border-radius: 50%;
+  width: 2rem;
+  height: 2rem;
+  font-size: 1.35rem;
+  cursor: pointer;
+}
+
+.modal__header h2 {
+  margin: 0;
+}
+
+.modal__header p {
+  color: var(--color-muted);
+}
+
+.modal__details {
+  padding-left: 1.1rem;
+  color: var(--color-muted);
+}
+
+.modal__checkout {
+  display: grid;
+  gap: 0.75rem;
+  margin: 1.5rem 0;
+}
+
+.toast {
+  position: fixed;
+  bottom: 1.5rem;
+  right: 1.5rem;
+  background: #1f2937;
+  color: white;
+  padding: 0.85rem 1.2rem;
+  border-radius: 0.85rem;
+  box-shadow: var(--shadow-md);
+  animation: fade-in 0.25s ease;
+}
+
+@keyframes fade-in {
+  from {
+    opacity: 0;
+    transform: translateY(10px);
+  }
+  to {
+    opacity: 1;
+    transform: translateY(0);
+  }
+}
+
+@media (max-width: 860px) {
+  .main-nav {
+    display: none;
+  }
+
+  .nav-toggle {
+    display: flex;
+  }
+
+  .mobile-nav[hidden] {
+    display: none;
+  }
+
+  .mobile-nav {
+    display: flex;
+  }
+}
+
+@media (max-width: 600px) {
+  .hero {
+    padding-top: 5rem;
+  }
+
+  .hero-stats {
+    flex-direction: column;
+    align-items: flex-start;
+  }
+}


### PR DESCRIPTION
## Summary
- add a responsive single-page "LectureVault" site for marketing and selling lecture downloads
- implement purchase modals with placeholder PayPal buttons, Stripe links, and gated download buttons
- include placeholder downloadable files and updated documentation for configuration

## Testing
- python -m http.server 8000

------
https://chatgpt.com/codex/tasks/task_e_68e582eed87883319cf734b557660618