### PR TITLE
Rebuild homepage to match Preply landing page

### DIFF
--- a/index.html
+++ b/index.html
@@ -1,436 +1,456 @@
 <!DOCTYPE html>
 <html lang="en">
-<head>
-  <meta charset="UTF-8" />
-  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-  <title>LectureVault | Premium Lecture Downloads</title>
-  <link rel="preconnect" href="https://fonts.googleapis.com" />
-  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
-  <link href="https://fonts.googleapis.com/css2?family=Inter:wght@300;400;600;700&display=swap" rel="stylesheet" />
-  <link rel="stylesheet" href="styles.css" />
-</head>
-<body>
-  <header class="site-header">
-    <div class="container header-content">
-      <a href="#hero" class="brand">LectureVault</a>
-      <nav class="main-nav" aria-label="Primary">
-        <a href="#lectures">Lectures</a>
-        <a href="#how-it-works">How it Works</a>
-        <a href="#pricing">Pricing</a>
-        <a href="#faq">FAQ</a>
-        <a href="#contact" class="btn btn-small btn-outline">Contact</a>
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Preply | Expert Online Tutors & Teachers</title>
+    <link rel="preconnect" href="https://fonts.googleapis.com" />
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+    <link
+      href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700;800&display=swap"
+      rel="stylesheet"
+    />
+    <link rel="stylesheet" href="styles.css" />
+  </head>
+  <body>
+    <header class="site-header">
+      <div class="container header-inner">
+        <a class="brand" href="#hero" aria-label="Preply home">
+          <span aria-hidden="true">Preply</span>
+        </a>
+        <nav class="main-nav" aria-label="Main navigation">
+          <a href="#subjects">Find tutors</a>
+          <a href="#corporate">Corporate</a>
+          <a href="#become-tutor">Become a tutor</a>
+          <a href="#support">Support</a>
+        </nav>
+        <div class="header-actions">
+          <a class="login-link" href="#">Log in</a>
+          <a class="btn btn-pill" href="#cta">Sign up</a>
+        </div>
+        <button
+          class="nav-toggle"
+          aria-expanded="false"
+          aria-controls="mobile-menu"
+          aria-label="Toggle navigation"
+        >
+          <span></span>
+          <span></span>
+          <span></span>
+        </button>
+      </div>
+      <nav id="mobile-menu" class="mobile-nav" aria-label="Mobile navigation" hidden>
+        <a href="#subjects">Find tutors</a>
+        <a href="#corporate">Corporate</a>
+        <a href="#become-tutor">Become a tutor</a>
+        <a href="#support">Support</a>
+        <a href="#" class="login-link">Log in</a>
+        <a href="#cta" class="btn btn-pill">Sign up</a>
       </nav>
-      <button class="nav-toggle" aria-expanded="false" aria-controls="mobile-menu" aria-label="Toggle navigation">
-        <span></span>
-        <span></span>
-        <span></span>
-      </button>
-    </div>
-    <nav id="mobile-menu" class="mobile-nav" hidden aria-label="Mobile navigation">
-      <a href="#lectures">Lectures</a>
-      <a href="#how-it-works">How it Works</a>
-      <a href="#pricing">Pricing</a>
-      <a href="#faq">FAQ</a>
-      <a href="#contact" class="btn btn-small btn-outline">Contact</a>
-    </nav>
-  </header>
+    </header>
 
-  <main>
-    <section id="hero" class="hero">
-      <div class="container hero-content">
-        <div class="hero-text">
-          <span class="badge">Downloadable Lecture Library</span>
-          <h1>Deliver your expertise with instant downloads and secure payments.</h1>
-          <p>
-            LectureVault makes it effortless for your students to find, purchase, and download your
-            lectures. Accept PayPal or Stripe, deliver files immediately, and keep everyone in sync.
-          </p>
-          <div class="cta-group">
-            <a class="btn" href="#lectures">Browse Lectures</a>
-            <a class="btn btn-outline" href="#how-it-works">See How It Works</a>
+    <main>
+      <section id="hero" class="hero">
+        <div class="container hero-grid">
+          <div class="hero-copy">
+            <span class="badge">1-on-1 language lessons</span>
+            <h1>Expert online tutors & teachers for private lessons</h1>
+            <p>
+              Learn with certified tutors from 185 countries. Take the first step toward fluency with
+              personalized lessons that fit your goals, schedule, and budget.
+            </p>
+            <ul class="hero-stats" role="list">
+              <li>
+                <strong>49,000+</strong>
+                <span>Experienced tutors</span>
+              </li>
+              <li>
+                <strong>120+</strong>
+                <span>Subjects taught</span>
+              </li>
+              <li>
+                <strong>4.9/5</strong>
+                <span>Average tutor rating</span>
+              </li>
+            </ul>
           </div>
-          <dl class="hero-stats">
-            <div>
-              <dt>1200+</dt>
-              <dd>Happy Learners</dd>
-            </div>
-            <div>
-              <dt>85</dt>
-              <dd>On-Demand Lectures</dd>
-            </div>
-            <div>
-              <dt>24/7</dt>
-              <dd>Instant Access</dd>
-            </div>
-          </dl>
+          <div class="hero-search" aria-labelledby="search-title">
+            <h2 id="search-title">Find your perfect tutor</h2>
+            <form class="search-form" novalidate>
+              <label for="subject">What do you want to learn?</label>
+              <div class="input-group">
+                <span class="icon" aria-hidden="true">🎓</span>
+                <select id="subject" name="subject">
+                  <option value="english" selected>English</option>
+                  <option value="spanish">Spanish</option>
+                  <option value="french">French</option>
+                  <option value="math">Math</option>
+                  <option value="programming">Programming</option>
+                </select>
+              </div>
+              <label for="where">Where are you from?</label>
+              <div class="input-group">
+                <span class="icon" aria-hidden="true">🌍</span>
+                <select id="where" name="where">
+                  <option value="anywhere" selected>Anywhere</option>
+                  <option value="usa">United States</option>
+                  <option value="uk">United Kingdom</option>
+                  <option value="brazil">Brazil</option>
+                  <option value="japan">Japan</option>
+                </select>
+              </div>
+              <label for="budget">What's your budget per lesson?</label>
+              <div class="range-row">
+                <input
+                  type="range"
+                  id="budget"
+                  name="budget"
+                  min="5"
+                  max="80"
+                  value="25"
+                  aria-describedby="budget-value"
+                />
+                <output id="budget-value" for="budget">$25</output>
+              </div>
+              <button type="submit" class="btn btn-pill">Search tutors</button>
+              <p class="form-hint">No subscription required. Pay as you go.</p>
+            </form>
+          </div>
         </div>
-        <div class="hero-card" role="presentation">
-          <div class="hero-card__header">
-            <h2>Featured Lecture</h2>
-            <p>AI Foundations Masterclass</p>
-          </div>
-          <ul class="hero-card__features">
-            <li>6.5 hours of HD content</li>
-            <li>Downloadable transcripts &amp; slides</li>
-            <li>Includes project workbook</li>
-          </ul>
-          <div class="hero-card__footer">
-            <span class="price">$49</span>
-            <a class="btn btn-small" href="#lectures">Get Access</a>
+        <div class="trust-bar" role="presentation">
+          <div class="container trust-grid">
+            <p>Trusted by learners from leading companies</p>
+            <ul role="list" class="logo-list">
+              <li>Zendesk</li>
+              <li>Canva</li>
+              <li>McKinsey</li>
+              <li>Eventbrite</li>
+              <li>EBay</li>
+            </ul>
           </div>
         </div>
-      </div>
-      <div class="hero-wave" aria-hidden="true"></div>
-    </section>
+      </section>
 
-    <section class="container section" id="lectures">
-      <header class="section-header">
-        <h2>Curated lectures, ready to download</h2>
-        <p>Each download includes video, audio, transcript, and bonus materials.</p>
-      </header>
-      <div class="filters" role="group" aria-label="Lecture filters">
-        <button class="filter-btn active" data-filter="all">All</button>
-        <button class="filter-btn" data-filter="technology">Technology</button>
-        <button class="filter-btn" data-filter="business">Business</button>
-        <button class="filter-btn" data-filter="creative">Creative</button>
-      </div>
-      <div class="lecture-grid" role="list">
-        <article class="lecture-card" role="listitem" data-category="technology">
-          <div class="lecture-card__body">
-            <span class="tag">Technology</span>
-            <h3>AI Foundations Masterclass</h3>
-            <p>Understand core machine learning concepts, model evaluation, and ethical AI practices.</p>
-            <ul>
-              <li>6.5 hours video • 220 page transcript</li>
-              <li>Includes interactive workbook</li>
-            </ul>
-          </div>
-          <footer class="lecture-card__footer">
-            <span class="price">$49</span>
-            <div class="actions">
-              <button class="btn btn-small" data-modal-target="modal-ai">Purchase</button>
-              <a class="link" href="downloads/ai-foundations-masterclass.pdf" download>Preview</a>
-            </div>
-          </footer>
-        </article>
-
-        <article class="lecture-card" role="listitem" data-category="business">
-          <div class="lecture-card__body">
-            <span class="tag">Business</span>
-            <h3>Startup Finance Essentials</h3>
-            <p>Learn how to budget, forecast, and pitch your startup with confidence.</p>
-            <ul>
-              <li>4.25 hours video • 150 page workbook</li>
-              <li>Includes editable financial models</li>
-            </ul>
-          </div>
-          <footer class="lecture-card__footer">
-            <span class="price">$39</span>
-            <div class="actions">
-              <button class="btn btn-small" data-modal-target="modal-finance">Purchase</button>
-              <a class="link" href="downloads/startup-finance-essentials.pdf" download>Preview</a>
-            </div>
-          </footer>
-        </article>
-
-        <article class="lecture-card" role="listitem" data-category="creative">
-          <div class="lecture-card__body">
-            <span class="tag">Creative</span>
-            <h3>Storytelling for Video Creators</h3>
-            <p>Craft compelling narratives and shot lists for YouTube and streaming platforms.</p>
-            <ul>
-              <li>3 hours video • 95 page creative guide</li>
-              <li>Includes editable storyboarding templates</li>
-            </ul>
-          </div>
-          <footer class="lecture-card__footer">
-            <span class="price">$32</span>
-            <div class="actions">
-              <button class="btn btn-small" data-modal-target="modal-story">Purchase</button>
-              <a class="link" href="downloads/storytelling-for-video-creators.pdf" download>Preview</a>
-            </div>
-          </footer>
-        </article>
-      </div>
-    </section>
-
-    <section class="section section-alt" id="how-it-works">
-      <div class="container split">
-        <div>
+      <section id="subjects" class="section subjects">
+        <div class="container">
           <header class="section-header">
-            <h2>Simple checkout, immediate delivery</h2>
-            <p>Students choose a lecture, pay securely, and receive instant download access.</p>
+            <h2>Popular online tutors</h2>
+            <p>Explore handpicked tutors ready to guide you through your language journey.</p>
           </header>
-          <ol class="steps">
+          <div class="subject-tabs" role="tablist" aria-label="Subjects">
+            <button class="tab-btn active" type="button" data-subject="english" role="tab" aria-selected="true">
+              English
+            </button>
+            <button class="tab-btn" type="button" data-subject="spanish" role="tab">Spanish</button>
+            <button class="tab-btn" type="button" data-subject="french" role="tab">French</button>
+            <button class="tab-btn" type="button" data-subject="german" role="tab">German</button>
+            <button class="tab-btn" type="button" data-subject="programming" role="tab">Programming</button>
+          </div>
+          <div class="tutor-grid" role="list">
+            <article class="tutor-card" data-subject-card="english" role="listitem">
+              <div class="tutor-card__top">
+                <span class="language">English</span>
+                <h3>Lauren M.</h3>
+                <p>TESOL certified with 8 years of experience helping professionals speak confidently.</p>
+              </div>
+              <ul class="tutor-meta" role="list">
+                <li>$28 per lesson</li>
+                <li>1,100+ lessons taught</li>
+                <li>Speaks English, Spanish</li>
+              </ul>
+              <button class="btn btn-pill">Book trial lesson</button>
+            </article>
+            <article class="tutor-card" data-subject-card="english" role="listitem">
+              <div class="tutor-card__top">
+                <span class="language">English</span>
+                <h3>Andrew P.</h3>
+                <p>Former IELTS examiner specializing in exam prep and academic writing.</p>
+              </div>
+              <ul class="tutor-meta" role="list">
+                <li>$32 per lesson</li>
+                <li>2,400+ lessons taught</li>
+                <li>Speaks English, German</li>
+              </ul>
+              <button class="btn btn-pill">Book trial lesson</button>
+            </article>
+            <article class="tutor-card" data-subject-card="spanish" role="listitem" hidden>
+              <div class="tutor-card__top">
+                <span class="language">Spanish</span>
+                <h3>María G.</h3>
+                <p>Native Spanish tutor for business professionals. Dynamic lessons tailored to your goals.</p>
+              </div>
+              <ul class="tutor-meta" role="list">
+                <li>$21 per lesson</li>
+                <li>1,800+ lessons taught</li>
+                <li>Speaks Spanish, English</li>
+              </ul>
+              <button class="btn btn-pill">Book trial lesson</button>
+            </article>
+            <article class="tutor-card" data-subject-card="spanish" role="listitem" hidden>
+              <div class="tutor-card__top">
+                <span class="language">Spanish</span>
+                <h3>Sergio H.</h3>
+                <p>DELE preparation specialist with interactive lessons focused on conversation.</p>
+              </div>
+              <ul class="tutor-meta" role="list">
+                <li>$18 per lesson</li>
+                <li>980+ lessons taught</li>
+                <li>Speaks Spanish, Italian</li>
+              </ul>
+              <button class="btn btn-pill">Book trial lesson</button>
+            </article>
+            <article class="tutor-card" data-subject-card="french" role="listitem" hidden>
+              <div class="tutor-card__top">
+                <span class="language">French</span>
+                <h3>Camille L.</h3>
+                <p>Alliance Française instructor helping learners master grammar and pronunciation.</p>
+              </div>
+              <ul class="tutor-meta" role="list">
+                <li>$30 per lesson</li>
+                <li>1,400+ lessons taught</li>
+                <li>Speaks French, English</li>
+              </ul>
+              <button class="btn btn-pill">Book trial lesson</button>
+            </article>
+            <article class="tutor-card" data-subject-card="german" role="listitem" hidden>
+              <div class="tutor-card__top">
+                <span class="language">German</span>
+                <h3>Felix R.</h3>
+                <p>Business German expert guiding teams toward confident professional communication.</p>
+              </div>
+              <ul class="tutor-meta" role="list">
+                <li>$35 per lesson</li>
+                <li>1,050+ lessons taught</li>
+                <li>Speaks German, English</li>
+              </ul>
+              <button class="btn btn-pill">Book trial lesson</button>
+            </article>
+            <article class="tutor-card" data-subject-card="programming" role="listitem" hidden>
+              <div class="tutor-card__top">
+                <span class="language">Programming</span>
+                <h3>Nikhil S.</h3>
+                <p>Software engineer teaching Python, JavaScript, and interview preparation.</p>
+              </div>
+              <ul class="tutor-meta" role="list">
+                <li>$40 per lesson</li>
+                <li>900+ lessons taught</li>
+                <li>Speaks English, Hindi</li>
+              </ul>
+              <button class="btn btn-pill">Book trial lesson</button>
+            </article>
+          </div>
+          <div class="cta-banner" id="cta">
+            <div>
+              <h3>Ready to start learning?</h3>
+              <p>Choose a tutor, pick a time, and begin your personalized lessons today.</p>
+            </div>
+            <a class="btn btn-pill" href="#hero">Get started</a>
+          </div>
+        </div>
+      </section>
+
+      <section class="section section-alt" id="corporate">
+        <div class="container features-grid">
+          <div>
+            <header class="section-header align-left">
+              <h2>Why learners choose Preply</h2>
+              <p>Stay motivated with proven methodology, expert tutors, and flexible scheduling.</p>
+            </header>
+            <ul class="feature-list" role="list">
+              <li>
+                <h3>Personalized plans</h3>
+                <p>Match with tutors who adapt every lesson to your level and goals.</p>
+              </li>
+              <li>
+                <h3>Flexible scheduling</h3>
+                <p>Book lessons that fit your calendar and reschedule with ease.</p>
+              </li>
+              <li>
+                <h3>Progress tracking</h3>
+                <p>Keep tabs on your progress with lesson summaries and learning milestones.</p>
+              </li>
+            </ul>
+          </div>
+          <div class="feature-card">
+            <h3>Corporate language training</h3>
+            <p>
+              Upskill global teams with dedicated account management, onboarding support, and detailed reporting.
+            </p>
+            <ul class="feature-points" role="list">
+              <li>Tailored learning paths for teams</li>
+              <li>Centralized billing & analytics</li>
+              <li>Enterprise-grade support</li>
+            </ul>
+            <a class="btn btn-pill" href="#">Talk to our team</a>
+          </div>
+        </div>
+      </section>
+
+      <section id="how" class="section steps">
+        <div class="container">
+          <header class="section-header">
+            <h2>How Preply works</h2>
+            <p>Getting started takes only a few minutes.</p>
+          </header>
+          <ol class="step-list">
             <li>
-              <h3>Choose a lecture</h3>
-              <p>Select from your catalog and open the purchase window to see the details.</p>
+              <span class="step-number">1</span>
+              <h3>Search for tutors</h3>
+              <p>Filter by subject, price, availability, and languages spoken.</p>
             </li>
             <li>
-              <h3>Secure payment</h3>
-              <p>Students pay with PayPal or Stripe. Replace the payment links with your own checkout URLs.</p>
+              <span class="step-number">2</span>
+              <h3>Book a trial lesson</h3>
+              <p>Connect with tutors, ask questions, and make sure it’s the right fit for you.</p>
             </li>
             <li>
-              <h3>Instant download</h3>
-              <p>After payment, the download button unlocks automatically for immediate access.</p>
+              <span class="step-number">3</span>
+              <h3>Schedule future lessons</h3>
+              <p>Stay consistent with weekly lessons and receive personalized homework.</p>
             </li>
           </ol>
         </div>
-        <div class="feature-card">
-          <h3>Included in every download</h3>
-          <ul>
-            <li>High-resolution MP4 video</li>
-            <li>MP3 audio-only version</li>
-            <li>Annotated PDF transcript</li>
-            <li>Bonus worksheets &amp; resources</li>
-            <li>Lifetime access to updates</li>
-          </ul>
-        </div>
-      </div>
-    </section>
+      </section>
 
-    <section class="section" id="pricing">
-      <div class="container">
-        <header class="section-header">
-          <h2>Bundles that grow with your audience</h2>
-          <p>Offer curated packages or sell lectures individually.</p>
-        </header>
-        <div class="pricing-grid">
-          <article class="pricing-card">
-            <h3>Single Lecture</h3>
-            <p class="price">$29 - $59</p>
-            <ul>
-              <li>Any individual lecture</li>
-              <li>Immediate download access</li>
-              <li>Payment by PayPal or Stripe</li>
-            </ul>
-            <a class="btn btn-small" href="#lectures">Choose a lecture</a>
-          </article>
-          <article class="pricing-card pricing-card--featured">
-            <div class="badge">Popular</div>
-            <h3>Complete Library</h3>
-            <p class="price">$249</p>
-            <ul>
-              <li>Includes every lecture &amp; update</li>
-              <li>One-click Stripe Checkout link</li>
-              <li>Priority support</li>
-            </ul>
-            <a class="btn btn-small" href="#contact">Request bundle link</a>
-          </article>
-          <article class="pricing-card">
-            <h3>Team Access</h3>
-            <p class="price">$499</p>
-            <ul>
-              <li>Up to 10 team members</li>
-              <li>Centralized billing</li>
-              <li>Automated lecture updates</li>
-            </ul>
-            <a class="btn btn-small btn-outline" href="#contact">Talk to sales</a>
-          </article>
-        </div>
-      </div>
-    </section>
-
-    <section class="section section-alt" id="faq">
-      <div class="container">
-        <header class="section-header">
-          <h2>Frequently Asked Questions</h2>
-        </header>
-        <div class="faq">
-          <details>
-            <summary>How do I connect my PayPal and Stripe accounts?</summary>
-            <p>
-              Replace the placeholder PayPal form URL and Stripe checkout links in the purchase modal with your
-              own links. Both providers let you create payment buttons or hosted checkout links without code.
-            </p>
-          </details>
-          <details>
-            <summary>When are downloads released to students?</summary>
-            <p>
-              After payment confirmation, the download button within the modal becomes active. Students can access
-              their files immediately and will receive a confirmation email with the download link if you integrate
-              email automation.
-            </p>
-          </details>
-          <details>
-            <summary>Can I host the lecture files elsewhere?</summary>
-            <p>
-              Absolutely. Replace the download URLs with links to your storage provider such as Dropbox, Google
-              Drive, or a private CDN. This demo uses local files for illustration.
-            </p>
-          </details>
-          <details>
-            <summary>Is there analytics for downloads?</summary>
-            <p>
-              You can connect Google Analytics or your preferred tracking tool to monitor page views and checkout
-              conversions. Stripe and PayPal each provide detailed payment reports.
-            </p>
-          </details>
-        </div>
-      </div>
-    </section>
-
-    <section class="section" id="contact">
-      <div class="container contact">
-        <div>
+      <section class="section section-alt testimonials">
+        <div class="container">
           <header class="section-header">
-            <h2>Need a custom lecture bundle?</h2>
-            <p>Fill in the form or email <a href="mailto:hello@lecturevault.com">hello@lecturevault.com</a> for a tailored offer.</p>
+            <h2>What our students say</h2>
+            <p>Thousands of learners rate Preply 4.9 out of 5 for quality and results.</p>
           </header>
-          <ul class="contact-benefits">
-            <li>48-hour response time</li>
-            <li>Bulk licensing discounts</li>
-            <li>White-label options</li>
+          <div class="testimonial-grid">
+            <figure class="testimonial-card">
+              <blockquote>
+                “Preply helped me become confident in business English before moving to London. My tutor keeps me
+                motivated with practical lessons.”
+              </blockquote>
+              <figcaption>
+                <strong>Lucía</strong>
+                <span>Marketing manager, Spain</span>
+              </figcaption>
+            </figure>
+            <figure class="testimonial-card">
+              <blockquote>
+                “I love the flexibility of scheduling and the quality of tutors. I can practice conversational
+                French anytime, anywhere.”
+              </blockquote>
+              <figcaption>
+                <strong>Christopher</strong>
+                <span>Product designer, USA</span>
+              </figcaption>
+            </figure>
+            <figure class="testimonial-card">
+              <blockquote>
+                “Our company uses Preply for corporate training. The reporting tools make it easy to track progress
+                across teams.”
+              </blockquote>
+              <figcaption>
+                <strong>Anaïs</strong>
+                <span>HR lead, France</span>
+              </figcaption>
+            </figure>
+          </div>
+        </div>
+      </section>
+
+      <section id="become-tutor" class="section tutor-cta">
+        <div class="container tutor-cta__inner">
+          <div class="tutor-copy">
+            <h2>Teach on Preply</h2>
+            <p>
+              Share your expertise with learners around the world. Set your own rates, choose your schedule, and
+              grow your tutoring business online.
+            </p>
+            <ul role="list">
+              <li>Access to thousands of motivated students</li>
+              <li>Secure payments for every lesson</li>
+              <li>Dedicated tutor success team</li>
+            </ul>
+            <a class="btn btn-pill" href="#">Become a tutor</a>
+          </div>
+          <div class="app-preview" aria-hidden="true">
+            <div class="preview-card">
+              <span class="badge">Tutor dashboard</span>
+              <p>Track lessons, respond to messages, and manage your calendar in one place.</p>
+            </div>
+            <div class="preview-card">
+              <span class="badge">Lesson planner</span>
+              <p>Stay organized with shared materials, homework, and progress notes.</p>
+            </div>
+          </div>
+        </div>
+      </section>
+
+      <section id="support" class="section faq">
+        <div class="container">
+          <header class="section-header">
+            <h2>Frequently asked questions</h2>
+            <p>Everything you need to know about starting your lessons.</p>
+          </header>
+          <div class="faq-grid">
+            <details open>
+              <summary>How quickly can I find a tutor?</summary>
+              <p>Most learners schedule a trial lesson within the first 24 hours of searching on Preply.</p>
+            </details>
+            <details>
+              <summary>Do I need a subscription?</summary>
+              <p>No. You purchase lesson hours in advance and can reschedule when you need to.</p>
+            </details>
+            <details>
+              <summary>What if I am not satisfied with a tutor?</summary>
+              <p>
+                Our tutor replacement guarantee means we will help you find another tutor at no additional cost.
+              </p>
+            </details>
+            <details>
+              <summary>Can companies use Preply?</summary>
+              <p>Yes. We provide dedicated support, reporting, and invoicing for corporate clients.</p>
+            </details>
+          </div>
+        </div>
+      </section>
+    </main>
+
+    <footer class="site-footer">
+      <div class="container footer-grid">
+        <div>
+          <a class="brand" href="#hero">Preply</a>
+          <p>Personalized learning journeys with trusted tutors from around the world.</p>
+        </div>
+        <div>
+          <h3>For learners</h3>
+          <ul>
+            <li><a href="#subjects">Find an English tutor</a></li>
+            <li><a href="#subjects">Find a Spanish tutor</a></li>
+            <li><a href="#subjects">Find a French tutor</a></li>
+            <li><a href="#how">How it works</a></li>
           </ul>
         </div>
-        <form class="contact-form" novalidate>
-          <div class="form-row">
-            <label for="name">Name</label>
-            <input id="name" name="name" type="text" placeholder="Your name" required />
-          </div>
-          <div class="form-row">
-            <label for="email">Email</label>
-            <input id="email" name="email" type="email" placeholder="you@example.com" required />
-          </div>
-          <div class="form-row">
-            <label for="message">Message</label>
-            <textarea id="message" name="message" rows="4" placeholder="Tell us what you need"></textarea>
-          </div>
-          <button type="submit" class="btn btn-small">Send message</button>
-          <p class="form-feedback" role="status" aria-live="polite"></p>
-        </form>
-      </div>
-    </section>
-  </main>
-
-  <footer class="site-footer">
-    <div class="container footer-grid">
-      <div>
-        <a href="#hero" class="brand">LectureVault</a>
-        <p class="footer-text">Delivering high-quality lectures with secure, instant downloads.</p>
-      </div>
-      <div>
-        <h3>Quick Links</h3>
-        <ul>
-          <li><a href="#lectures">Lectures</a></li>
-          <li><a href="#pricing">Pricing</a></li>
-          <li><a href="#faq">FAQ</a></li>
-          <li><a href="#contact">Contact</a></li>
-        </ul>
-      </div>
-      <div>
-        <h3>Stay Updated</h3>
-        <form class="newsletter" novalidate>
-          <label class="sr-only" for="newsletter-email">Email</label>
-          <input id="newsletter-email" type="email" name="email" placeholder="Email address" required />
-          <button type="submit" class="btn btn-small">Join</button>
-          <p class="form-feedback" role="status" aria-live="polite"></p>
-        </form>
-      </div>
-    </div>
-    <p class="legal">© <span id="year"></span> LectureVault. All rights reserved.</p>
-  </footer>
-
-  <div class="modal" id="modal-ai" role="dialog" aria-modal="true" aria-labelledby="modal-ai-title" hidden>
-    <div class="modal__backdrop" data-close></div>
-    <div class="modal__dialog">
-      <button class="modal__close" data-close aria-label="Close">
-        <span>&times;</span>
-      </button>
-      <div class="modal__header">
-        <h2 id="modal-ai-title">AI Foundations Masterclass</h2>
-        <p>Secure your copy with PayPal or Stripe.</p>
-      </div>
-      <div class="modal__content">
-        <ul class="modal__details">
-          <li>6.5 hours on-demand video</li>
-          <li>Transcripts, slides, and workbook</li>
-          <li>Instant download unlock after payment</li>
-        </ul>
-        <div class="modal__checkout">
-          <form class="paypal-form" action="https://www.paypal.com/cgi-bin/webscr" method="post" target="_blank">
-            <input type="hidden" name="cmd" value="_s-xclick" />
-            <input type="hidden" name="hosted_button_id" value="REPLACE_WITH_YOUR_BUTTON_ID" />
-            <button type="submit" class="btn btn-paypal">Pay with PayPal</button>
-          </form>
-          <a class="btn btn-stripe" href="https://buy.stripe.com/test_000000000000" target="_blank" rel="noopener">Pay with Stripe</a>
+        <div>
+          <h3>For tutors</h3>
+          <ul>
+            <li><a href="#become-tutor">Teach online</a></li>
+            <li><a href="#become-tutor">Tutor resources</a></li>
+            <li><a href="#support">Help center</a></li>
+          </ul>
         </div>
-        <button class="btn btn-small btn-success" data-unlock="ai">I have completed payment</button>
-        <a class="btn btn-small btn-outline" data-download="ai" href="downloads/ai-foundations-masterclass.pdf" download hidden>
-          Download lecture
-        </a>
-      </div>
-    </div>
-  </div>
-
-  <div class="modal" id="modal-finance" role="dialog" aria-modal="true" aria-labelledby="modal-finance-title" hidden>
-    <div class="modal__backdrop" data-close></div>
-    <div class="modal__dialog">
-      <button class="modal__close" data-close aria-label="Close">
-        <span>&times;</span>
-      </button>
-      <div class="modal__header">
-        <h2 id="modal-finance-title">Startup Finance Essentials</h2>
-        <p>Purchase securely and download immediately.</p>
-      </div>
-      <div class="modal__content">
-        <ul class="modal__details">
-          <li>Budgeting, forecasting, and investor pitch prep</li>
-          <li>Editable financial templates</li>
-          <li>Full transcript and slides</li>
-        </ul>
-        <div class="modal__checkout">
-          <form class="paypal-form" action="https://www.paypal.com/cgi-bin/webscr" method="post" target="_blank">
-            <input type="hidden" name="cmd" value="_s-xclick" />
-            <input type="hidden" name="hosted_button_id" value="REPLACE_WITH_YOUR_BUTTON_ID" />
-            <button type="submit" class="btn btn-paypal">Pay with PayPal</button>
+        <div>
+          <h3>Stay in the loop</h3>
+          <form class="newsletter" novalidate>
+            <label for="newsletter-email" class="sr-only">Email</label>
+            <input id="newsletter-email" type="email" name="email" placeholder="Email address" required />
+            <button type="submit" class="btn btn-pill">Subscribe</button>
+            <p class="form-feedback" role="status" aria-live="polite"></p>
           </form>
-          <a class="btn btn-stripe" href="https://buy.stripe.com/test_111111111111" target="_blank" rel="noopener">Pay with Stripe</a>
         </div>
-        <button class="btn btn-small btn-success" data-unlock="finance">I have completed payment</button>
-        <a class="btn btn-small btn-outline" data-download="finance" href="downloads/startup-finance-essentials.pdf" download hidden>
-          Download lecture
-        </a>
       </div>
-    </div>
-  </div>
+      <p class="legal">© <span id="year"></span> Preply. All rights reserved.</p>
+    </footer>
 
-  <div class="modal" id="modal-story" role="dialog" aria-modal="true" aria-labelledby="modal-story-title" hidden>
-    <div class="modal__backdrop" data-close></div>
-    <div class="modal__dialog">
-      <button class="modal__close" data-close aria-label="Close">
-        <span>&times;</span>
-      </button>
-      <div class="modal__header">
-        <h2 id="modal-story-title">Storytelling for Video Creators</h2>
-        <p>Secure checkout with PayPal or Stripe.</p>
-      </div>
-      <div class="modal__content">
-        <ul class="modal__details">
-          <li>Story structure frameworks</li>
-          <li>Editable script templates</li>
-          <li>Access to bonus resources</li>
-        </ul>
-        <div class="modal__checkout">
-          <form class="paypal-form" action="https://www.paypal.com/cgi-bin/webscr" method="post" target="_blank">
-            <input type="hidden" name="cmd" value="_s-xclick" />
-            <input type="hidden" name="hosted_button_id" value="REPLACE_WITH_YOUR_BUTTON_ID" />
-            <button type="submit" class="btn btn-paypal">Pay with PayPal</button>
-          </form>
-          <a class="btn btn-stripe" href="https://buy.stripe.com/test_222222222222" target="_blank" rel="noopener">Pay with Stripe</a>
-        </div>
-        <button class="btn btn-small btn-success" data-unlock="story">I have completed payment</button>
-        <a class="btn btn-small btn-outline" data-download="story" href="downloads/storytelling-for-video-creators.pdf" download hidden>
-          Download lecture
-        </a>
-      </div>
-    </div>
-  </div>
+    <template id="toast-template">
+      <div class="toast" role="status" aria-live="polite"></div>
+    </template>
 
-  <template id="toast-template">
-    <div class="toast" role="status" aria-live="assertive"></div>
-  </template>
-
-  <script src="scripts.js" defer></script>
-</body>
+    <script src="scripts.js" defer></script>
+  </body>
 </html>

--- a/scripts.js
+++ b/scripts.js
@@ -1,80 +1,75 @@
 (function () {
   const navToggle = document.querySelector('.nav-toggle');
   const mobileMenu = document.getElementById('mobile-menu');
-  const filterButtons = document.querySelectorAll('.filter-btn');
-  const lectureCards = document.querySelectorAll('.lecture-card');
-  const modals = document.querySelectorAll('.modal');
+  const subjectButtons = document.querySelectorAll('.tab-btn');
+  const tutorCards = document.querySelectorAll('[data-subject-card]');
+  const budgetRange = document.getElementById('budget');
+  const budgetValue = document.getElementById('budget-value');
+  const forms = document.querySelectorAll('form');
   const toastTemplate = document.getElementById('toast-template');
   const yearEl = document.getElementById('year');
-  const contactForm = document.querySelector('.contact-form');
-  const newsletterForm = document.querySelector('.newsletter');
 
-  yearEl.textContent = new Date().getFullYear();
+  if (yearEl) {
+    yearEl.textContent = new Date().getFullYear();
+  }
 
   const toggleMobileMenu = () => {
+    if (!navToggle || !mobileMenu) return;
     const expanded = navToggle.getAttribute('aria-expanded') === 'true';
     navToggle.setAttribute('aria-expanded', String(!expanded));
     mobileMenu.toggleAttribute('hidden');
   };
 
-  navToggle.addEventListener('click', toggleMobileMenu);
+  if (navToggle && mobileMenu) {
+    navToggle.addEventListener('click', toggleMobileMenu);
 
-  mobileMenu.querySelectorAll('a').forEach((link) => {
-    link.addEventListener('click', () => {
-      if (window.innerWidth <= 860) {
-        toggleMobileMenu();
-      }
-    });
-  });
-
-  const filterLectures = (category) => {
-    lectureCards.forEach((card) => {
-      const matches = category === 'all' || card.dataset.category === category;
-      card.hidden = !matches;
-    });
-  };
-
-  filterButtons.forEach((btn) => {
-    btn.addEventListener('click', () => {
-      filterButtons.forEach((item) => item.classList.remove('active'));
-      btn.classList.add('active');
-      filterLectures(btn.dataset.filter);
-    });
-  });
-
-  const openModal = (id) => {
-    const modal = document.getElementById(id);
-    if (!modal) return;
-    modal.hidden = false;
-    document.body.style.overflow = 'hidden';
-  };
-
-  const closeModal = (modal) => {
-    modal.hidden = true;
-    document.body.style.overflow = '';
-  };
-
-  document.addEventListener('click', (event) => {
-    const trigger = event.target.closest('[data-modal-target]');
-    if (trigger) {
-      openModal(trigger.dataset.modalTarget);
-    }
-
-    if (event.target.matches('[data-close]')) {
-      const modal = event.target.closest('.modal');
-      if (modal) closeModal(modal);
-    }
-  });
-
-  window.addEventListener('keydown', (event) => {
-    if (event.key === 'Escape') {
-      modals.forEach((modal) => {
-        if (!modal.hidden) closeModal(modal);
+    mobileMenu.querySelectorAll('a').forEach((link) => {
+      link.addEventListener('click', () => {
+        if (window.innerWidth < 820) {
+          toggleMobileMenu();
+        }
       });
+    });
+  }
+
+  const showSubject = (subject) => {
+    tutorCards.forEach((card) => {
+      const matches = subject === card.dataset.subjectCard;
+      card.toggleAttribute('hidden', !matches);
+    });
+  };
+
+  if (subjectButtons.length) {
+    const activeButton = Array.from(subjectButtons).find((button) => button.classList.contains('active'));
+    if (activeButton) {
+      showSubject(activeButton.dataset.subject);
     }
-  });
+
+    subjectButtons.forEach((button) => {
+      button.addEventListener('click', () => {
+        subjectButtons.forEach((item) => {
+          item.classList.remove('active');
+          item.setAttribute('aria-selected', 'false');
+        });
+
+        button.classList.add('active');
+        button.setAttribute('aria-selected', 'true');
+        showSubject(button.dataset.subject);
+      });
+    });
+  }
+
+  if (budgetRange && budgetValue) {
+    const updateBudget = () => {
+      budgetValue.textContent = `$${budgetRange.value}`;
+    };
+
+    budgetRange.addEventListener('input', updateBudget);
+    updateBudget();
+  }
 
   const showToast = (message) => {
+    if (!toastTemplate) return;
     const toast = toastTemplate.content.firstElementChild.cloneNode(true);
     toast.textContent = message;
     document.body.appendChild(toast);
@@ -85,39 +80,30 @@
     }, 2600);
   };
 
-  document.querySelectorAll('[data-unlock]').forEach((button) => {
-    button.addEventListener('click', () => {
-      const key = button.dataset.unlock;
-      const downloadLink = document.querySelector(`[data-download="${key}"]`);
-      if (!downloadLink) return;
-      downloadLink.hidden = false;
-      showToast('Download unlocked! Enjoy your lecture.');
-    });
-  });
-
-  const setupForm = (form) => {
-    if (!form) return;
+  forms.forEach((form) => {
     const feedback = form.querySelector('.form-feedback');
 
     form.addEventListener('submit', (event) => {
       event.preventDefault();
       const formData = new FormData(form);
-      const hasEmptyRequired = Array.from(form.querySelectorAll('[required]')).some((field) => {
-        return !String(formData.get(field.name)).trim();
-      });
+      const requiredFields = Array.from(form.querySelectorAll('[required]'));
+      const hasEmptyRequired = requiredFields.some((field) => !String(formData.get(field.name)).trim());
 
       if (hasEmptyRequired) {
-        feedback.textContent = 'Please fill in all required fields.';
-        feedback.style.color = '#ef4444';
+        if (feedback) {
+          feedback.textContent = 'Please fill in the required fields.';
+          feedback.style.color = '#ff6b6b';
+        }
+        showToast('Please complete the highlighted fields.');
         return;
       }
 
-      feedback.textContent = 'Thanks! We will get back to you soon.';
-      feedback.style.color = 'var(--color-primary)';
+      if (feedback) {
+        feedback.textContent = 'Thanks! We will be in touch soon.';
+        feedback.style.color = 'var(--color-primary)';
+      }
       form.reset();
+      showToast('Form submitted successfully.');
     });
-  };
-
-  setupForm(contactForm);
-  setupForm(newsletterForm);
+  });
 })();

--- a/styles.css
+++ b/styles.css
@@ -1,14 +1,15 @@
 :root {
-  --color-bg: #f6f7fb;
+  --color-primary: #00c1a5;
+  --color-primary-dark: #009b81;
+  --color-secondary: #14324c;
+  --color-accent: #f8f9fb;
   --color-surface: #ffffff;
-  --color-primary: #3b82f6;
-  --color-primary-dark: #1d4ed8;
-  --color-secondary: #6366f1;
-  --color-accent: #22c55e;
-  --color-text: #1f2937;
-  --color-muted: #6b7280;
-  --shadow-sm: 0 5px 20px rgba(15, 23, 42, 0.08);
-  --shadow-md: 0 12px 30px rgba(15, 23, 42, 0.15);
+  --color-muted: #5c6b7b;
+  --color-border: #dbe5ef;
+  --gradient-hero: linear-gradient(135deg, #ecfefd, #e8f3ff);
+  --gradient-cta: linear-gradient(120deg, #00c1a5, #2b76ff);
+  --shadow-sm: 0 10px 30px rgba(14, 44, 74, 0.08);
+  --shadow-md: 0 18px 40px rgba(14, 44, 74, 0.12);
   font-family: "Inter", system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
   scroll-behavior: smooth;
 }
@@ -19,15 +20,10 @@
 
 body {
   margin: 0;
-  color: var(--color-text);
-  background: var(--color-bg);
+  background: var(--color-accent);
+  color: var(--color-secondary);
   font-size: 16px;
   line-height: 1.6;
-}
-
-img {
-  max-width: 100%;
-  display: block;
 }
 
 a {
@@ -40,8 +36,13 @@ a:focus {
   color: var(--color-primary);
 }
 
+img {
+  max-width: 100%;
+  display: block;
+}
+
 .container {
-  width: min(1100px, 92vw);
+  width: min(1120px, 92vw);
   margin: 0 auto;
 }
 
@@ -50,62 +51,42 @@ a:focus {
   align-items: center;
   justify-content: center;
   gap: 0.5rem;
-  padding: 0.85rem 1.4rem;
-  border-radius: 999px;
-  font-weight: 600;
   border: none;
   cursor: pointer;
-  background: linear-gradient(135deg, var(--color-primary), var(--color-secondary));
-  color: #fff;
+  color: #ffffff;
+  background: var(--gradient-cta);
+  font-weight: 600;
   transition: transform 0.2s ease, box-shadow 0.2s ease;
   box-shadow: var(--shadow-sm);
 }
 
-.btn:hover,
-.btn:focus {
-  transform: translateY(-2px);
-  box-shadow: var(--shadow-md);
-}
-
-.btn-small {
-  padding: 0.65rem 1.1rem;
+.btn-pill {
+  padding: 0.9rem 1.7rem;
+  border-radius: 999px;
   font-size: 0.95rem;
 }
 
-.btn-outline {
-  background: transparent;
-  color: var(--color-primary);
-  border: 1px solid rgba(59, 130, 246, 0.5);
-  box-shadow: none;
+.btn:hover,
+.btn:focus {
+  transform: translateY(-1px);
+  box-shadow: var(--shadow-md);
 }
 
-.btn-outline:hover,
-.btn-outline:focus {
-  background: rgba(59, 130, 246, 0.08);
-}
-
-.btn-paypal {
-  background: linear-gradient(135deg, #ffc439, #ff9f0c);
-  color: #1f2937;
-}
-
-.btn-stripe {
-  background: linear-gradient(135deg, #6772e5, #4338ca);
-}
-
-.btn-success {
-  background: linear-gradient(135deg, var(--color-accent), #16a34a);
+.login-link {
+  font-weight: 500;
+  color: var(--color-muted);
+  margin-right: 1.25rem;
 }
 
 .site-header {
-  background: var(--color-surface);
   position: sticky;
   top: 0;
-  z-index: 10;
-  box-shadow: 0 1px 0 rgba(15, 23, 42, 0.05);
+  z-index: 20;
+  background: var(--color-surface);
+  border-bottom: 1px solid rgba(20, 50, 76, 0.06);
 }
 
-.header-content {
+.header-inner {
   display: flex;
   align-items: center;
   justify-content: space-between;
@@ -113,20 +94,21 @@ a:focus {
 }
 
 .brand {
-  font-weight: 700;
-  font-size: 1.2rem;
-  letter-spacing: -0.02em;
+  font-weight: 800;
+  font-size: 1.4rem;
+  letter-spacing: -0.03em;
+  color: var(--color-secondary);
 }
 
 .main-nav {
   display: flex;
-  align-items: center;
   gap: 1.5rem;
   font-weight: 500;
 }
 
 .main-nav a {
   position: relative;
+  padding: 0.25rem 0;
 }
 
 .main-nav a::after {
@@ -148,131 +130,193 @@ a:focus {
   transform-origin: left;
 }
 
+.header-actions {
+  display: flex;
+  align-items: center;
+}
+
 .nav-toggle {
   display: none;
   flex-direction: column;
-  gap: 0.35rem;
-  border: none;
+  gap: 0.4rem;
   background: transparent;
+  border: none;
   cursor: pointer;
 }
 
 .nav-toggle span {
   display: block;
-  width: 1.5rem;
+  width: 1.6rem;
   height: 2px;
-  background: var(--color-text);
-  transition: transform 0.2s ease, opacity 0.2s ease;
+  background: var(--color-secondary);
+  transition: transform 0.3s ease, opacity 0.3s ease;
 }
 
 .mobile-nav {
   display: none;
   flex-direction: column;
-  padding: 0 1.5rem 1.5rem;
-  gap: 0.85rem;
+  gap: 1rem;
+  padding: 1.5rem;
   background: var(--color-surface);
-  box-shadow: 0 15px 25px rgba(15, 23, 42, 0.08);
+  border-bottom: 1px solid rgba(20, 50, 76, 0.08);
 }
 
 .hero {
-  padding: 6rem 0 4rem;
+  padding: 4rem 0 3rem;
+  background: var(--gradient-hero);
   position: relative;
-  overflow: hidden;
 }
 
-.hero-wave {
-  position: absolute;
-  inset: auto 0 0;
-  height: 200px;
-  background: linear-gradient(180deg, rgba(59, 130, 246, 0.08), rgba(59, 130, 246, 0));
-  pointer-events: none;
-}
-
-.hero-content {
+.hero-grid {
   display: grid;
-  grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
-  gap: 3rem;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 3.5rem;
   align-items: center;
-}
-
-.hero-text h1 {
-  font-size: clamp(2.2rem, 4vw + 1rem, 3.5rem);
-  line-height: 1.15;
-  margin-bottom: 1rem;
-}
-
-.hero-text p {
-  font-size: 1.05rem;
-  color: var(--color-muted);
-  max-width: 34rem;
 }
 
 .badge {
   display: inline-flex;
   align-items: center;
-  gap: 0.35rem;
-  padding: 0.35rem 0.75rem;
-  background: rgba(59, 130, 246, 0.12);
-  color: var(--color-primary);
+  gap: 0.5rem;
+  padding: 0.35rem 0.9rem;
   border-radius: 999px;
+  font-size: 0.85rem;
   font-weight: 600;
-  margin-bottom: 1rem;
+  background: rgba(0, 193, 165, 0.12);
+  color: var(--color-primary-dark);
+}
+
+.hero-copy h1 {
+  font-size: clamp(2.6rem, 4vw + 1rem, 3.6rem);
+  line-height: 1.1;
+  margin: 1.2rem 0 1rem;
+}
+
+.hero-copy p {
+  font-size: 1.1rem;
+  color: var(--color-muted);
+  margin-bottom: 2rem;
 }
 
 .hero-stats {
   display: flex;
-  gap: 2rem;
-  margin-top: 2.5rem;
+  gap: 2.5rem;
+  padding: 0;
+  margin: 0;
+  list-style: none;
+  color: var(--color-secondary);
 }
 
-.hero-stats dt {
-  font-size: 1.8rem;
+.hero-stats strong {
+  display: block;
+  font-size: 1.6rem;
   font-weight: 700;
 }
 
-.hero-stats dd {
-  margin: 0;
+.hero-stats span {
   color: var(--color-muted);
+  font-size: 0.95rem;
 }
 
-.hero-card {
+.hero-search {
   background: var(--color-surface);
-  border-radius: 1.5rem;
-  padding: 2rem;
-  box-shadow: var(--shadow-md);
+  padding: 2.5rem;
+  border-radius: 24px;
+  box-shadow: var(--shadow-sm);
 }
 
-.hero-card__header h2 {
-  margin: 0;
-  font-size: 1.35rem;
+.hero-search h2 {
+  margin-top: 0;
+  font-size: 1.45rem;
 }
 
-.hero-card__header p {
-  margin-top: 0.25rem;
-  color: var(--color-muted);
-}
-
-.hero-card__features {
-  list-style: none;
-  padding: 0;
-  margin: 1.5rem 0;
+.search-form {
   display: grid;
-  gap: 0.75rem;
+  gap: 1rem;
 }
 
-.hero-card__footer {
+.search-form label {
+  font-weight: 600;
+  font-size: 0.95rem;
+  color: var(--color-secondary);
+}
+
+.input-group {
+  position: relative;
+  display: flex;
+  align-items: center;
+  border: 1px solid var(--color-border);
+  border-radius: 14px;
+  padding: 0.4rem 0.75rem;
+  background: var(--color-surface);
+}
+
+.input-group select {
+  flex: 1;
+  border: none;
+  padding: 0.6rem 0.5rem 0.6rem 0.35rem;
+  font-size: 1rem;
+  background: transparent;
+  color: var(--color-secondary);
+}
+
+.input-group select:focus {
+  outline: none;
+}
+
+.icon {
+  font-size: 1.2rem;
+}
+
+.range-row {
+  display: grid;
+  grid-template-columns: 1fr auto;
+  gap: 0.75rem;
+  align-items: center;
+}
+
+.range-row input[type="range"] {
+  width: 100%;
+}
+
+.range-row output {
+  font-weight: 600;
+  color: var(--color-primary-dark);
+}
+
+.form-hint {
+  margin: 0;
+  font-size: 0.9rem;
+  color: var(--color-muted);
+  text-align: center;
+}
+
+.trust-bar {
+  margin-top: 3rem;
+  padding: 1.5rem 0;
+  border-top: 1px solid rgba(20, 50, 76, 0.08);
+}
+
+.trust-grid {
   display: flex;
   align-items: center;
   justify-content: space-between;
+  gap: 2rem;
+  flex-wrap: wrap;
 }
 
-.price {
-  font-weight: 700;
-  font-size: 1.25rem;
+.logo-list {
+  display: flex;
+  gap: 2rem;
+  padding: 0;
+  margin: 0;
+  list-style: none;
+  color: var(--color-muted);
+  font-weight: 600;
 }
 
 .section {
-  padding: 5rem 0;
+  padding: 4.5rem 0;
 }
 
 .section-alt {
@@ -281,276 +325,356 @@ a:focus {
 
 .section-header {
   text-align: center;
-  margin-bottom: 3rem;
-}
-
-.section-header h2 {
-  margin: 0;
-  font-size: clamp(2rem, 3vw + 1rem, 2.8rem);
-}
-
-.section-header p {
-  color: var(--color-muted);
-  max-width: 34rem;
-  margin: 0.75rem auto 0;
-}
-
-.filters {
-  display: flex;
-  justify-content: center;
-  gap: 0.75rem;
-  flex-wrap: wrap;
   margin-bottom: 2.5rem;
 }
 
-.filter-btn {
-  border: 1px solid rgba(59, 130, 246, 0.3);
-  background: transparent;
+.section-header h2 {
+  margin: 0 0 0.75rem;
+  font-size: 2rem;
+}
+
+.section-header p {
+  margin: 0;
   color: var(--color-muted);
-  padding: 0.5rem 1.2rem;
+}
+
+.section-header.align-left {
+  text-align: left;
+}
+
+.subject-tabs {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.75rem;
+  justify-content: center;
+  margin-bottom: 2rem;
+}
+
+.tab-btn {
+  padding: 0.65rem 1.5rem;
   border-radius: 999px;
+  border: 1px solid var(--color-border);
+  background: var(--color-surface);
+  color: var(--color-muted);
   font-weight: 600;
   cursor: pointer;
-  transition: background 0.2s ease, color 0.2s ease, border 0.2s ease;
+  transition: all 0.2s ease;
 }
 
-.filter-btn.active,
-.filter-btn:hover,
-.filter-btn:focus {
-  background: rgba(59, 130, 246, 0.12);
-  color: var(--color-primary);
+.tab-btn:hover,
+.tab-btn:focus {
   border-color: var(--color-primary);
+  color: var(--color-primary);
 }
 
-.lecture-grid {
+.tab-btn.active {
+  background: rgba(0, 193, 165, 0.12);
+  color: var(--color-primary-dark);
+  border-color: transparent;
+}
+
+.tutor-grid {
   display: grid;
-  grid-template-columns: repeat(auto-fit, minmax(270px, 1fr));
-  gap: 1.8rem;
+  grid-template-columns: repeat(auto-fit, minmax(250px, 1fr));
+  gap: 1.5rem;
 }
 
-.lecture-card {
+.tutor-card {
   background: var(--color-surface);
-  border-radius: 1.25rem;
+  border-radius: 20px;
   padding: 1.8rem;
   box-shadow: var(--shadow-sm);
   display: flex;
   flex-direction: column;
-  justify-content: space-between;
-  gap: 1.5rem;
+  gap: 1rem;
 }
 
-.lecture-card__body h3 {
-  margin: 0 0 0.75rem;
+.tutor-card__top h3 {
+  margin: 0.5rem 0 0.75rem;
+  font-size: 1.2rem;
 }
 
-.lecture-card__body p {
-  color: var(--color-muted);
-  margin: 0 0 1rem;
-}
-
-.lecture-card__body ul {
+.tutor-card__top p {
   margin: 0;
-  padding-left: 1.2rem;
   color: var(--color-muted);
 }
 
-.lecture-card__footer {
+.language {
+  display: inline-block;
+  font-size: 0.8rem;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: var(--color-primary-dark);
+}
+
+.tutor-meta {
+  display: grid;
+  gap: 0.4rem;
+  margin: 0;
+  padding: 0;
+  list-style: none;
+  color: var(--color-muted);
+  font-size: 0.95rem;
+}
+
+.tutor-card .btn {
+  align-self: flex-start;
+}
+
+.cta-banner {
+  margin-top: 3rem;
+  padding: 2rem 2.5rem;
+  border-radius: 24px;
+  background: var(--gradient-cta);
+  color: #ffffff;
   display: flex;
   align-items: center;
   justify-content: space-between;
+  gap: 2rem;
+  flex-wrap: wrap;
 }
 
-.tag {
-  display: inline-flex;
-  align-items: center;
-  padding: 0.3rem 0.75rem;
-  border-radius: 999px;
-  background: rgba(59, 130, 246, 0.08);
-  color: var(--color-primary);
-  font-weight: 600;
-  margin-bottom: 0.75rem;
+.cta-banner h3 {
+  margin: 0 0 0.5rem;
+  font-size: 1.6rem;
 }
 
-.link {
-  font-weight: 600;
-  color: var(--color-primary);
+.cta-banner p {
+  margin: 0;
 }
 
-.split {
+.cta-banner .btn {
+  background: #ffffff;
+  color: var(--color-secondary);
+  box-shadow: none;
+}
+
+.features-grid {
   display: grid;
   grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
-  gap: 3rem;
-  align-items: center;
+  gap: 2.5rem;
+  align-items: start;
 }
 
-.steps {
+.feature-list {
   list-style: none;
   margin: 0;
   padding: 0;
   display: grid;
-  gap: 1.8rem;
+  gap: 1.5rem;
 }
 
-.steps h3 {
-  margin-bottom: 0.35rem;
+.feature-list h3 {
+  margin: 0 0 0.35rem;
+}
+
+.feature-list p {
+  margin: 0;
+  color: var(--color-muted);
 }
 
 .feature-card {
-  background: linear-gradient(160deg, rgba(59, 130, 246, 0.12), rgba(34, 197, 94, 0.12));
-  border-radius: 1.5rem;
+  background: var(--color-surface);
   padding: 2rem;
+  border-radius: 24px;
   box-shadow: var(--shadow-sm);
+  display: grid;
+  gap: 1.25rem;
 }
 
-.feature-card ul {
+.feature-points {
   margin: 0;
   padding-left: 1.1rem;
   color: var(--color-muted);
 }
 
-.pricing-grid {
+.steps {
+  background: var(--color-accent);
+}
+
+.step-list {
+  list-style: none;
+  margin: 0;
+  padding: 0;
   display: grid;
-  grid-template-columns: repeat(auto-fit, minmax(250px, 1fr));
+  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
   gap: 2rem;
 }
 
-.pricing-card {
+.step-list li {
   background: var(--color-surface);
+  border-radius: 20px;
   padding: 2rem;
-  border-radius: 1.5rem;
   box-shadow: var(--shadow-sm);
-  text-align: center;
-  position: relative;
 }
 
-.pricing-card ul {
-  list-style: none;
-  padding: 0;
-  margin: 1.5rem 0;
-  color: var(--color-muted);
+.step-number {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 44px;
+  height: 44px;
+  border-radius: 50%;
+  background: rgba(0, 193, 165, 0.12);
+  color: var(--color-primary-dark);
+  font-weight: 700;
+  font-size: 1.1rem;
+  margin-bottom: 1rem;
+}
+
+.testimonial-grid {
   display: grid;
-  gap: 0.65rem;
+  grid-template-columns: repeat(auto-fit, minmax(240px, 1fr));
+  gap: 1.5rem;
 }
 
-.pricing-card--featured {
-  background: linear-gradient(160deg, rgba(59, 130, 246, 0.12), rgba(99, 102, 241, 0.12));
-  border: 1px solid rgba(59, 130, 246, 0.2);
+.testimonial-card {
+  background: var(--color-surface);
+  border-radius: 20px;
+  padding: 2rem;
+  display: grid;
+  gap: 1.25rem;
+  box-shadow: var(--shadow-sm);
 }
 
-.pricing-card .badge {
-  position: absolute;
-  top: 1.5rem;
-  right: 1.5rem;
+.testimonial-card blockquote {
+  margin: 0;
+  font-style: italic;
+  color: var(--color-secondary);
 }
 
-.faq {
+.testimonial-card span {
+  color: var(--color-muted);
+  font-size: 0.9rem;
+}
+
+.tutor-cta {
+  background: var(--gradient-cta);
+  color: #ffffff;
+}
+
+.tutor-cta__inner {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
+  gap: 3rem;
+  align-items: center;
+}
+
+.tutor-copy ul {
+  margin: 1.5rem 0;
+  padding-left: 1.2rem;
+}
+
+.tutor-copy li {
+  margin-bottom: 0.5rem;
+}
+
+.tutor-copy .btn {
+  background: #ffffff;
+  color: var(--color-secondary);
+}
+
+.app-preview {
+  display: grid;
+  gap: 1.5rem;
+}
+
+.preview-card {
+  background: rgba(255, 255, 255, 0.15);
+  padding: 1.75rem;
+  border-radius: 20px;
+  backdrop-filter: blur(6px);
+}
+
+.preview-card p {
+  margin: 0.75rem 0 0;
+}
+
+.faq-grid {
   display: grid;
   gap: 1rem;
+  max-width: 760px;
+  margin: 0 auto;
 }
 
-.faq details {
+.faq-grid details {
   background: var(--color-surface);
-  border-radius: 1.1rem;
-  padding: 1.5rem;
+  border-radius: 16px;
+  padding: 1.2rem 1.5rem;
   box-shadow: var(--shadow-sm);
 }
 
-.faq summary {
+.faq-grid summary {
   font-weight: 600;
   cursor: pointer;
 }
 
-.contact {
-  display: grid;
-  grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
-  gap: 3rem;
-  align-items: start;
-}
-
-.contact-benefits {
-  margin: 2rem 0 0;
-  padding-left: 1.2rem;
-  color: var(--color-muted);
-}
-
-.contact-form,
-.newsletter {
-  background: var(--color-surface);
-  border-radius: 1.25rem;
-  padding: 2rem;
-  box-shadow: var(--shadow-sm);
-  display: grid;
-  gap: 1.2rem;
-}
-
-.form-row {
-  display: grid;
-  gap: 0.35rem;
-}
-
-label {
-  font-weight: 600;
-  font-size: 0.95rem;
-}
-
-input,
-textarea {
-  width: 100%;
-  border-radius: 0.8rem;
-  border: 1px solid rgba(148, 163, 184, 0.6);
-  padding: 0.85rem 1rem;
-  font: inherit;
-  transition: border 0.2s ease, box-shadow 0.2s ease;
-}
-
-input:focus,
-textarea:focus {
-  outline: none;
-  border-color: var(--color-primary);
-  box-shadow: 0 0 0 3px rgba(59, 130, 246, 0.2);
-}
-
-textarea {
-  resize: vertical;
-}
-
-.form-feedback {
-  margin: 0;
-  min-height: 1.2rem;
-  font-size: 0.9rem;
-  color: var(--color-muted);
-}
-
 .site-footer {
-  background: #0f172a;
-  color: rgba(255, 255, 255, 0.85);
-  padding: 4rem 0 2rem;
+  background: #0d2337;
+  color: rgba(255, 255, 255, 0.9);
+  padding: 3.5rem 0 2.5rem;
 }
 
 .footer-grid {
   display: grid;
-  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+  grid-template-columns: repeat(auto-fit, minmax(200px, 1fr));
   gap: 2.5rem;
+  align-items: start;
 }
 
-.footer-text {
-  max-width: 18rem;
-  color: rgba(255, 255, 255, 0.7);
+.footer-grid h3 {
+  margin-top: 0;
+  margin-bottom: 1rem;
 }
 
-.site-footer a {
-  color: rgba(255, 255, 255, 0.75);
+.footer-grid ul {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: grid;
+  gap: 0.6rem;
 }
 
-.site-footer a:hover,
-.site-footer a:focus {
-  color: #fff;
+.footer-grid a {
+  color: rgba(255, 255, 255, 0.8);
+}
+
+.footer-grid a:hover,
+.footer-grid a:focus {
+  color: #ffffff;
+}
+
+.newsletter {
+  display: grid;
+  gap: 0.75rem;
+}
+
+.newsletter input {
+  border-radius: 999px;
+  border: none;
+  padding: 0.85rem 1.1rem;
+  font-size: 0.95rem;
+}
+
+.newsletter input:focus {
+  outline: 2px solid rgba(255, 255, 255, 0.6);
 }
 
 .legal {
+  margin: 2.5rem 0 0;
   text-align: center;
-  margin-top: 3rem;
-  color: rgba(255, 255, 255, 0.6);
+  color: rgba(255, 255, 255, 0.65);
+}
+
+.toast {
+  position: fixed;
+  inset: auto 1.5rem 1.5rem auto;
+  background: var(--color-secondary);
+  color: #ffffff;
+  padding: 0.85rem 1.4rem;
+  border-radius: 999px;
+  box-shadow: var(--shadow-md);
+  transition: opacity 0.3s ease, transform 0.3s ease;
 }
 
 .sr-only {
@@ -565,92 +689,23 @@ textarea {
   border: 0;
 }
 
-.modal {
-  position: fixed;
-  inset: 0;
-  display: grid;
-  place-items: center;
-  padding: 1.5rem;
-}
-
-.modal[hidden] {
-  display: none;
-}
-
-.modal__backdrop {
-  position: absolute;
-  inset: 0;
-  background: rgba(15, 23, 42, 0.55);
-}
-
-.modal__dialog {
-  position: relative;
-  background: var(--color-surface);
-  border-radius: 1.5rem;
-  padding: 2.2rem;
-  box-shadow: var(--shadow-md);
-  width: min(480px, 92vw);
-  max-height: calc(100vh - 3rem);
-  overflow-y: auto;
-}
-
-.modal__close {
-  position: absolute;
-  top: 1rem;
-  right: 1rem;
-  border: none;
-  background: rgba(148, 163, 184, 0.2);
-  border-radius: 50%;
-  width: 2rem;
-  height: 2rem;
-  font-size: 1.35rem;
-  cursor: pointer;
-}
-
-.modal__header h2 {
-  margin: 0;
-}
-
-.modal__header p {
-  color: var(--color-muted);
-}
-
-.modal__details {
-  padding-left: 1.1rem;
-  color: var(--color-muted);
-}
-
-.modal__checkout {
-  display: grid;
-  gap: 0.75rem;
-  margin: 1.5rem 0;
-}
-
-.toast {
-  position: fixed;
-  bottom: 1.5rem;
-  right: 1.5rem;
-  background: #1f2937;
-  color: white;
-  padding: 0.85rem 1.2rem;
-  border-radius: 0.85rem;
-  box-shadow: var(--shadow-md);
-  animation: fade-in 0.25s ease;
-}
-
-@keyframes fade-in {
-  from {
-    opacity: 0;
-    transform: translateY(10px);
+@media (max-width: 960px) {
+  .hero-grid {
+    grid-template-columns: 1fr;
   }
-  to {
-    opacity: 1;
-    transform: translateY(0);
+
+  .hero-search {
+    order: -1;
+  }
+
+  .hero-stats {
+    justify-content: space-between;
   }
 }
 
-@media (max-width: 860px) {
-  .main-nav {
+@media (max-width: 820px) {
+  .main-nav,
+  .header-actions {
     display: none;
   }
 
@@ -665,15 +720,53 @@ textarea {
   .mobile-nav {
     display: flex;
   }
+
+  .subject-tabs {
+    justify-content: flex-start;
+  }
 }
 
-@media (max-width: 600px) {
+@media (max-width: 680px) {
   .hero {
-    padding-top: 5rem;
+    padding-top: 3rem;
+  }
+
+  .hero-search {
+    padding: 2rem 1.5rem;
   }
 
   .hero-stats {
     flex-direction: column;
     align-items: flex-start;
+    gap: 1rem;
+  }
+
+  .cta-banner {
+    flex-direction: column;
+    align-items: flex-start;
+  }
+
+  .trust-grid {
+    flex-direction: column;
+    align-items: flex-start;
+  }
+
+  .logo-list {
+    flex-wrap: wrap;
+    gap: 1rem 1.5rem;
+  }
+}
+
+@media (max-width: 520px) {
+  .search-form {
+    gap: 0.85rem;
+  }
+
+  .tutor-card {
+    padding: 1.5rem;
+  }
+
+  .step-list li {
+    padding: 1.6rem;
   }
 }


### PR DESCRIPTION
## Summary
- replace the existing landing page content with a Preply-inspired structure including hero, tutor listings, testimonials, and FAQ
- refresh the site styling with new typography, color palette, responsive layout rules, and utility styles
- streamline JavaScript for mobile navigation, subject tab filtering, budget slider feedback, and form toasts

## Testing
- python -m http.server 8000

------
https://chatgpt.com/codex/tasks/task_e_68e5a6a0da44833192f39ad9158eb2ae